### PR TITLE
OpenAPI v3.0.x support

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -36,20 +36,16 @@ class parser {
       spec = {};
     }
 
-    const version = spec.swagger || spec.openapi;
-    switch (version) {
-      case "2.0":
+    if (spec.swagger && spec.swagger.indexOf("2.0") === 0) {
         const parserV2 = new ParserV2();
-        return parserV2.parse(spec);
-
-      case "3.0.0":
-        const parserV3 = new ParserV3();
-        return parserV3.parse(spec);
-
-      default:
-        throw new Error(
-          "'specification' parameter must contain a valid version 2.0 or 3.0.0 specification"
-        );
+		return parserV2.parse(spec);
+    } else if (spec.openapi && spec.openapi.indexOf("3.0") === 0) {
+		const parserV3 = new ParserV3();
+		return parserV3.parse(spec);
+    } else {
+		throw new Error(
+			"'specification' parameter must contain a valid version 2.0 or 3.0.0 specification"
+		);
     }
   }
 }

--- a/test/test-generate-project.js
+++ b/test/test-generate-project.js
@@ -2,9 +2,11 @@ const t = require("tap");
 const test = t.test;
 
 const path = require("path");
+const fs = require("fs");
 const Generator = require("../lib/generator");
 
 const specPath = path.join(__dirname, "petstore-swagger.v2.json");
+const specPath3 = path.join(__dirname, "petstore-openapi.v3.json");
 const projectName = "generatedProject";
 const dir = path.resolve(__dirname, "../examples");
 const nonExistentDir = path.join(__dirname, "non-existent-directory");
@@ -19,6 +21,30 @@ test("generator generates project without error", t => {
   t.plan(1);
   generator
     .parse(specPath)
+    .then(_ => {
+      generator.generateProject(dir, projectName);
+      t.pass("no error occurred");
+    })
+    .catch(e => t.fail(e.message));
+});
+
+test("generator generates V3.0.0 project without error", t => {
+  t.plan(1);
+  generator
+    .parse(specPath3)
+    .then(_ => {
+      generator.generateProject(dir, projectName);
+      t.pass("no error occurred");
+    })
+    .catch(e => t.fail(e.message));
+});
+
+test("generator generates V3.0.1 project without error", t => {
+  const spec301 = JSON.parse(fs.readFileSync(specPath3, 'utf8'));
+  spec301["openapi"] = "3.0.1";
+  t.plan(1);
+  generator
+    .parse(spec301)
     .then(_ => {
       generator.generateProject(dir, projectName);
       t.pass("no error occurred");

--- a/test/test-plugin.v3.js
+++ b/test/test-plugin.v3.js
@@ -244,3 +244,24 @@ test("full pet store V3 definition does not throw error ", t => {
     }
   });
 });
+
+test("V3.0.1 definition does not throw error", t => {
+	const spec301 = JSON.parse(JSON.stringify(petStoreSpec));
+	spec301["openapi"] = "3.0.1";
+	const opts301 = {
+		specification: spec301,
+		service
+	};
+
+	t.plan(1);
+	const fastify = Fastify();
+	fastify.register(fastifyOpenapiGlue, opts301);
+	fastify.ready(err => {
+		if (err) {
+			t.fail("got unexpected error");
+		} else {
+			t.pass("no unexpected error");
+		}
+	});
+});
+


### PR DESCRIPTION
Hi! 

A small fix to allow OpenAPI 3.0.1 files to be used as soon as they are supported by [swagger-parser](https://github.com/BigstickCarpet/swagger-parser/blob/master/lib/index.js#L61). 

Best!