### PR TITLE
add logging to parser error

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -32,6 +32,8 @@ class parser {
       // and validate
       spec = await swp.validate(data);
     } catch (e) {
+      // eslint-disable-next-line
+      console.log(e.message);
       data = {};
       spec = {};
     }


### PR DESCRIPTION
If `swagger-parser` throws an error, the error message is logged to the console.