### PR TITLE
Updated dependencies

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,14 @@
 
 ## [current release]
 ### Changed
+ - Updated dependencies
+   - ajv              ^6.11.0  →   ^6.12.0 
+   - fastify-plugin    ^1.6.0  →    ^1.6.1 
+   - minimist          ^1.2.0  →    ^1.2.5 
+   - swagger-parser    ^9.0.0  →    ^9.0.1 
+    - fastify          ^2.11.0  →   ^2.13.0 
+   - fastify-cli       ^1.3.0  →    ^1.5.0 
+    - tap             ^14.10.6  →  ^14.10.7 
 
 ## [1.5.0] 31-01-2020
 ### Changed
@@ -11,11 +19,11 @@
 ### Changed
  - Added nullable flag to ajv config
  - Updated dependencies
-  - ajv              ^6.10.2  →   ^6.11.0 
-  - ajv-oai           ^1.1.5  →    ^1.2.0 
-  - swagger-parser    ^8.0.3  →    ^8.0.4 
-  - fastify          ^2.10.0  →   ^2.11.0 
-  - tap             ^14.10.2  →  ^14.10.6 
+   - ajv              ^6.10.2  →   ^6.11.0 
+   - ajv-oai           ^1.1.5  →    ^1.2.0 
+   - swagger-parser    ^8.0.3  →    ^8.0.4 
+   - fastify          ^2.10.0  →   ^2.11.0 
+   - tap             ^14.10.2  →  ^14.10.6 
 
 ## [1.3.1] 29-11-2019
 ### Changed

--- a/examples/generatedProject/package.json
+++ b/examples/generatedProject/package.json
@@ -11,11 +11,11 @@
     "test": "test"
   },
   "dependencies": {
-    "fastify-plugin": "^1.6.0"
+    "fastify-plugin": "^1.6.1"
   },
   "devDependencies": {
-    "fastify": "^2.11.0",
-    "fastify-cli": "^1.3.0",
-    "tap": "^14.10.6"
+    "fastify": "^2.13.0",
+    "fastify-cli": "^1.5.0",
+    "tap": "^14.10.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,12 +18,12 @@
     "openapi-glue": "./bin/openapi-glue-cli.js"
   },
   "dependencies": {
-    "ajv": "^6.11.0",
+    "ajv": "^6.12.0",
     "ajv-oai": "^1.2.0",
-    "fastify-plugin": "^1.6.0",
+    "fastify-plugin": "^1.6.1",
     "js-yaml": "^3.13.1",
-    "minimist": "^1.2.0",
-    "swagger-parser": "^9.0.0"
+    "minimist": "^1.2.5",
+    "swagger-parser": "^9.0.1"
   },
   "directories": {
     "example": "./examples",
@@ -32,9 +32,9 @@
     "bin": "./bin"
   },
   "devDependencies": {
-    "fastify": "^2.11.0",
-    "fastify-cli": "^1.3.0",
-    "tap": "^14.10.6"
+    "fastify": "^2.13.0",
+    "fastify-cli": "^1.5.0",
+    "tap": "^14.10.7"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
 ajv              ^6.11.0  →   ^6.12.0 
 fastify-plugin    ^1.6.0  →    ^1.6.1 
 minimist          ^1.2.0  →    ^1.2.5 
 swagger-parser    ^9.0.0  →    ^9.0.1 
 fastify          ^2.11.0  →   ^2.13.0 
 fastify-cli       ^1.3.0  →    ^1.5.0 
 tap             ^14.10.6  →  ^14.10.7 