### PR TITLE
Add ability to pass options through to AJV

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,12 @@ const options = {
   specification: `${__dirname}/petstore-swagger.v2.json`,
   service: `${__dirname}/service.js`,
   prefix: "v1",
-  noAdditional: true
+  noAdditional: true,
+  ajvOptions: {
+    formats: {
+      "custom-format": /\d{2}-\d{4}/
+    }
+  }
 };
 
 
@@ -35,6 +40,7 @@ All schema and routes will be taken from the OpenApi specification listed in the
   - `service`: this can be a javascript object or class, or the name of a javascript file containing such an object. If the import of the file results in a function instead of an object then the function will be executed during import.
   - `prefix`: this is a string that can be used to prefix the routes, it is passed verbatim to fastify. E.g. if the path to your operation is specified as "/operation" then a prefix of "v1" will make it available at "/v1/operation". This setting overrules any "basePath" setting in a v2 specification. 
   - `noAdditional`: by default Fastify will silently ignore additional properties in a message. Setting `noAdditional` to `true` will change this behaviour and will make Fastify return a HTTP error 400 when additional properties are present. Default value for this option is `false`.
+  - `ajvOptions`: Pass additional options to AJV (see https://ajv.js.org/#options)
 
 `specification` and `service` are mandatory, `prefix` and `noAdditional` are optional.
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -10,6 +10,7 @@ declare module 'fastify-openapi-glue'
       service: string | object | Function;
       prefix?: string;
       noAdditional?: boolean;
+      ajvOptions: object;
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -48,12 +48,14 @@ async function fastifyOpenapiGlue(instance, opts) {
 
   // AJV misses some validators for int32, int64 etc which ajv-oai adds
   const Ajv = require("ajv-oai");
-  const ajv = new Ajv({  // the fastify defaults
+  let ajvOptions = {  // the fastify defaults
     removeAdditional: !opts.noAdditional,
     useDefaults: true,
     coerceTypes: true,
     nullable: true
-  });
+  }
+  Object.assign(ajvOptions, opts.ajvOptions)
+  const ajv = new Ajv(ajvOptions);
 
   instance.setSchemaCompiler(schema => ajv.compile(schema));
 

--- a/test/test-openapi.v3.json
+++ b/test/test-openapi.v3.json
@@ -193,7 +193,8 @@
         "additionalProperties":false,
         "properties": {
           "str1": {
-            "type": "string"
+            "type": "string",
+            "format": "custom-format"
           }
         },
         "required": [

--- a/test/test-openapi.v3.yaml
+++ b/test/test-openapi.v3.yaml
@@ -99,6 +99,7 @@ components:
       properties:
         str1:
           type: string
+          format: custom-format
       required:
         - str1
     responseObject:

--- a/test/test-plugin.v3.js
+++ b/test/test-plugin.v3.js
@@ -11,7 +11,12 @@ const genericPathItemsSpec = require("./test-openapi-v3-generic-path-items.json"
 const service = require(serviceFile);
 const opts = {
   specification: testSpec,
-  service
+  service,
+  ajvOptions: {
+    formats: {
+      "custom-format": /test data/
+    }
+  }
 };
 
 const prefixOpts = {
@@ -170,6 +175,26 @@ test("body parameters work", t => {
   );
 });
 
+test("body parameters that don't match custom-format set through ajvOptions returns error 400", t => {
+  t.plan(2);
+  const fastify = Fastify();
+  fastify.register(fastifyOpenapiGlue, opts);
+
+  fastify.inject(
+    {
+      method: "post",
+      url: "/bodyParam",
+      payload: {
+        str1: "WRONG-FORMAT",
+        str2: "test data",
+     }
+    },
+    (err, res) => {
+      t.error(err);
+      t.strictEqual(res.statusCode, 400);
+    }
+  );
+});
 
 test("extra body parameters with ajv opts returns error 400", t => {
   t.plan(2);


### PR DESCRIPTION
Hi there @seriousme.  How do you feel about a change like this to allow AJV to be configured?  Fastify allows its default AJV instance to be configured by specifying`ajv.customOptions` in the Fastify options, but since fastify-openapi-glue overrides the default schemaCompiler, those options get overwritten.