### PR TITLE
Enable passthrough of security handler errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -87,6 +87,7 @@ async function fastifyOpenapiGlue(instance, opts) {
     let secHandler = async (req, reply) => {
       let numSchemes = schemes.length;
       let numChecks = 0;
+      let handlerErrors = [];
       for (let scheme of schemes) {
         numChecks++;
 
@@ -95,12 +96,14 @@ async function fastifyOpenapiGlue(instance, opts) {
           return; // If one security check passes, no need to try any others
         } catch (err) {
           req.log.debug('Security check failed:', err, err.stack);
+          handlerErrors.push(err);
 
           // Only throw if no security handlers validated this request
           if (numChecks === numSchemes) {
             let err = new Error(`None of the security schemes (${schemes.join(', ')}) successfully authenticated this request.`);
             err.statusCode = 401;
             err.name = 'Unauthorized';
+            err.errors = handlerErrors;
             throw err;
           }
         }

--- a/test/test-plugin.v2.js
+++ b/test/test-plugin.v2.js
@@ -268,8 +268,12 @@ test("v2 security registration succeeds, but preHandler throws error", t => {
     }
   };
 
-  t.plan(3);
+  t.plan(4);
   const fastify = Fastify();
+  fastify.setErrorHandler((err, req, reply) => {
+    t.strictEqual(err.errors.length, 1);
+    reply.code(err.statusCode).send(err);
+  });
   fastify.register(fastifyOpenapiGlue, opts);
   fastify.inject(
     {
@@ -320,8 +324,12 @@ test("v2 security preHandler handles multiple failures", t => {
     }
   };
 
-  t.plan(3);
+  t.plan(4);
   const fastify = Fastify();
+  fastify.setErrorHandler((err, req, reply) => {
+    t.strictEqual(err.errors.length, 2);
+    reply.code(err.statusCode).send(err);
+  });
   fastify.register(fastifyOpenapiGlue, opts);
   fastify.inject(
     {

--- a/test/test-plugin.v3.js
+++ b/test/test-plugin.v3.js
@@ -480,8 +480,12 @@ test("v3 security preHandler throws error", t => {
     }
   };
 
-  t.plan(3);
+  t.plan(4);
   const fastify = Fastify();
+  fastify.setErrorHandler((err, req, reply) => {
+    t.strictEqual(err.errors.length, 1);
+    reply.code(err.statusCode).send(err);
+  });
   fastify.register(fastifyOpenapiGlue, opts);
   fastify.inject(
     {
@@ -532,8 +536,12 @@ test("v3 security preHandler handles multiple failures", t => {
     }
   };
 
-  t.plan(3);
+  t.plan(4);
   const fastify = Fastify();
+  fastify.setErrorHandler((err, req, reply) => {
+    t.strictEqual(err.errors.length, 2);
+    reply.code(err.statusCode).send(err);
+  });
   fastify.register(fastifyOpenapiGlue, opts);
   fastify.inject(
     {


### PR DESCRIPTION
I thought it would be useful if errors thrown within the security handlers could be captured and used further down the request chain.

For example, someone may want to pass more specific auth reasons back to the API client as to why authentication failed. In this case, they could use `fastify.setErrorHandler` to grab the specific error messages and return them as part of the response.

If this looks ok, I can also throw some readme updates in.