### PR TITLE
Fix stripResponseFormats for recursive schemas

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,13 +26,16 @@ function getObject(param) {
 // from the responses
 const unknownFormats = { int32: true, int64: true };
 
-function stripResponseFormats(schema) {
-  for (let item in schema) {
+function stripResponseFormats(schema, visited = new Set()) {
+  for (const item in schema) {
     if (isObject(schema[item])) {
       if (schema[item].format && unknownFormats[schema[item].format]) {
         schema[item].format = undefined;
       }
-      stripResponseFormats(schema[item]);
+      if (!visited.has(item)) {
+        visited.add(item);
+        stripResponseFormats(schema[item], visited);
+      }
     }
   }
 }


### PR DESCRIPTION
If used with recursive schema (Generic Tree structure, linked list, etc) current code will fail with 
```cmd
 'Maximum call stack size exceeded'

  › stripResponseFormats (node_modules/fastify-openapi-glue/index.js:29:30)
  › stripResponseFormats (node_modules/fastify-openapi-glue/index.js:35:7)
  › stripResponseFormats (node_modules/fastify-openapi-glue/index.js:35:7)
  › stripResponseFormats (node_modules/fastify-openapi-glue/index.js:35:7)
  › stripResponseFormats (node_modules/fastify-openapi-glue/index.js:35:7)
  › stripResponseFormats (node_modules/fastify-openapi-glue/index.js:35:7)
  › stripResponseFormats (node_modules/fastify-openapi-glue/index.js:35:7)
  › stripResponseFormats (node_modules/fastify-openapi-glue/index.js:35:7)
  › stripResponseFormats (node_modules/fastify-openapi-glue/index.js:35:7)
  › stripResponseFormats (node_modules/fastify-openapi-glue/index.js:35:7)
```

AFAIK `ajv` preserves `ref`s reference equality and will, therefore, work with a simple `visited` Set.