### PR TITLE
Remove noisy console log statement

### DIFF
--- a/lib/parser.v3.js
+++ b/lib/parser.v3.js
@@ -94,9 +94,6 @@ class parserV3 {
     let schema;
     if (data && data.content) {
       for (let mimeType in data.content) {
-        if (mimeType !== "application/json") {
-          console.log(`body type: ${mimeType} found`);
-        }
         schema = data.content[mimeType].schema;
       }
     }


### PR DESCRIPTION
Hi @seriousme -- is it possible to remove this console log statement?  Now that I've added an API endpoint that returns 'text/plain', this log statement is making my test suite quite noisy.  Thanks!