### PR TITLE
add securityHandlers parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ All schema and routes will be taken from the OpenApi specification listed in the
 ### Options
   - `specification`: this can be a JSON object, or the name of a JSON or YAML file containing a valid OpenApi(v2/v3) file 
   - `service`: this can be a javascript object or class, or the name of a javascript file containing such an object. If the import of the file results in a function instead of an object then the function will be executed during import.
-  - `securityHandlers`: this can be a javascript object or class, or the name of a javascript file containing such an object. If the import of the file results in a function instead of an object then the function will be executed during import.
+  - `securityHandlers`: this can be a javascript object or class, or the name of a javascript file containing such an object. If the import of the file results in a function instead of an object then the function will be executed during import. See the [securityHandlers documentation](docs/securityHandlers.md) for more details.
   - `prefix`: this is a string that can be used to prefix the routes, it is passed verbatim to fastify. E.g. if the path to your operation is specified as "/operation" then a prefix of "v1" will make it available at "/v1/operation". This setting overrules any "basePath" setting in a v2 specification. 
   - `noAdditional`: by default Fastify will silently ignore additional properties in a message. Setting `noAdditional` to `true` will change this behaviour and will make Fastify return a HTTP error 400 when additional properties are present. Default value for this option is `false`.
   - `ajvOptions`: Pass additional options to AJV (see https://ajv.js.org/#options)
@@ -50,15 +50,6 @@ All schema and routes will be taken from the OpenApi specification listed in the
 `specification` and `service` are mandatory, `securityHandlers`, `prefix` and `noAdditional` are optional.
 
 See the [examples](#examples) section for a demo.
-
-Any errors that result from `securityHandlers` are available to registered error handlers. E.g.:
-```javascript
-  fastify.setErrorHandler((err, req, reply) => {
-    reply.code(err.statusCode).send(err);
-  });
-```
-will return errors originating from the securityHandlers as well.
-**Please make sure this does not expose sensitive information to the requestor!**
 
 <a name="generator"></a>
 ## Generator

--- a/docs/securityHandlers.md
+++ b/docs/securityHandlers.md
@@ -1,0 +1,43 @@
+<h1 align="center">fastify-openapi-glue</h1>
+
+## SecurityHandlers
+The [OpenApi](https://www.openapis.org/) `Operation object allows for `security requirements` that speficify which security scheme(s) should be applied to this operation.
+
+You can specify your own securityHandlers with the `securityHandlers` option.
+If the provided object has an `initialize` function then fastify-openapi-glue will call this function with the `/components/securitySchemes` property (v3) or the `/securityDefinitions` property (v2) of the specification provided.
+
+### Example
+
+In the petstore example specification there is a section:
+```json
+"/pet": {
+      "post": {
+       ...
+        "summary": "Add a new pet to the store",
+        "description": "",
+        "operationId": "addPet",
+        ...
+        "security": [
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ],
+```
+
+If you provide a securityHandler called `petstore_auth` then it will be called as `petstore_auth(request,reply, params)` where request and reply will be fastify request and reply objects and params contains `["write:pets", "read:pets"]`.
+
+If you want authentication to succeed you can simply return. If you want authentication to fail you can just throw an error. 
+
+Any errors that result from `securityHandlers` are available to registered error handlers. E.g.:
+```javascript
+  fastify.setErrorHandler((err, req, reply) => {
+    reply.code(err.statusCode).send(err);
+  });
+```
+will return errors originating from the securityHandlers as well.
+**Please make sure this does not expose sensitive information to the requestor!**
+
+For a more elaborate example see the [examples/generatedProject](examples/generatedProject) folder.

--- a/examples/generatedProject/security.js
+++ b/examples/generatedProject/security.js
@@ -3,10 +3,15 @@
 class Security {
   constructor() {}
 
+  initialize(schemes){
+    // schemes will contain securitySchemes as found in the openapi specification
+    console.log("Initialize:", JSON.stringify(schemes));
+  }
+
 
   // Security scheme: petstore_auth
   // Type: oauth2
-  async petstore_auth(req, reply) {
+  async petstore_auth(req, reply, params) {
     console.log("petstore_auth: Authenticating request");
     
     // If validation fails: throw new Error('Could not authenticate request')
@@ -17,7 +22,7 @@ class Security {
 
   // Security scheme: api_key
   // Type: apiKey
-  async api_key(req, reply) {
+  async api_key(req, reply, params) {
     console.log("api_key: Authenticating request");
     
     // If validation fails: throw new Error('Could not authenticate request')

--- a/index.js
+++ b/index.js
@@ -94,12 +94,16 @@ async function fastifyOpenapiGlue(instance, opts) {
   }
 
   let security;
+  let securityHandlers;
   if (opts.securityHandlers) {
-    const securityHandlers = await getObject(opts.securityHandlers);
+    securityHandlers = await getObject(opts.securityHandlers);
     if (!isObject(securityHandlers)) {
       throw new Error("'securityHandlers' parameter must refer to an object");
     }
     security = new Security(securityHandlers);
+    if ("initialize" in securityHandlers){
+      securityHandlers.initialize(config.securitySchemes);
+    }
   }
 
   async function generateRoutes(routesInstance, routesOpts) {
@@ -117,7 +121,7 @@ async function fastifyOpenapiGlue(instance, opts) {
 
       // Apply security requirements if present and at least one handler is defined
       if (security && security.has(item.security)) {
-        item.preHandler = security.get(item.security).bind(routesInstance);
+        item.preHandler = security.get(item.security).bind(securityHandlers);
       }
       routesInstance.route(item);
     });

--- a/lib/parser.v2.js
+++ b/lib/parser.v2.js
@@ -129,6 +129,10 @@ class parserV2 extends parserBase {
           break;
         case "basePath":
           this.config.prefix = spec[item];
+        // the missing break is on purpose !
+        case "securityDefinitions":
+          this.config.securitySchemes = spec[item];
+        // the missing break is on purpose !
         default:
           this.config.generic[item] = spec[item];
       }

--- a/lib/parser.v3.js
+++ b/lib/parser.v3.js
@@ -152,6 +152,10 @@ class parserV3 extends parserBase {
         case "paths":
           this.processPaths(spec.paths);
           break;
+        case "components":
+          if (spec.components.securitySchemes) {
+            this.config.securitySchemes = spec.components.securitySchemes;
+          } // the missing break is on purpose !
         default:
           this.config.generic[item] = spec[item];
       }

--- a/lib/parserBase.js
+++ b/lib/parserBase.js
@@ -31,6 +31,14 @@ module.exports = class parserBase {
   }
 
   parseSecurity(schemes) {
-    return schemes ? schemes.map((item) => Object.keys(item)[0]) : undefined;
+    return schemes ? schemes.map((item) => {
+      const name = Object.keys(item)[0];
+      return {
+        name,
+        parameters: item[name]
+      }
+      
+    }) : undefined;
+    //return schemes ? schemes.map((item) => Object.keys(item)[0]) : undefined;
   }
 };

--- a/lib/securityHandlers.js
+++ b/lib/securityHandlers.js
@@ -5,7 +5,7 @@ module.exports = class Security {
   constructor(handlers) {
     this.handlers = handlers;
     // the specificatio allows for an empty scheme that allows all access
-    this.handlers[emptyScheme] = async () => {};
+    this.handlers[emptyScheme] = async () => { };
     this.handlerMap = new Map();
     this.missingHandlers = [];
     return this;
@@ -20,14 +20,14 @@ module.exports = class Security {
       const processedSchemes = [];
       schemes.forEach((scheme) => {
         // parser returns undefined on empty scheme
-        if (scheme === undefined) {
-          scheme = emptyScheme;
+        if (scheme.name === undefined) {
+          scheme.name = emptyScheme;
         }
-        if (!(scheme in this.handlers)) {
-          this.handlers[scheme] = () => {
-            throw `Missing handler for "${scheme}" validation`;
+        if (!(scheme.name in this.handlers)) {
+          this.handlers[scheme.name] = () => {
+            throw `Missing handler for "${scheme.name}" validation`;
           };
-          this.missingHandlers.push(scheme);
+          this.missingHandlers.push(scheme.name);
         }
         processedSchemes.push(scheme);
       });
@@ -49,18 +49,20 @@ module.exports = class Security {
     const securityHandlers = this.handlers;
     return async (req, reply) => {
       const handlerErrors = [];
+      const schemeList = [];
       for (const scheme of schemes) {
         try {
-          await securityHandlers[scheme](req, reply);
+          await securityHandlers[scheme.name](req, reply, scheme.parameters);
           return; // If one security check passes, no need to try any others
         } catch (err) {
           req.log.debug("Security check failed:", err, err.stack);
           handlerErrors.push(err);
         }
+        schemeList.push(scheme.name)
       }
       // if we get this far no security handlers validated this request
       const err = new Error(
-        `None of the security schemes (${schemes.join(
+        `None of the security schemes (${schemeList.join(
           ", "
         )}) successfully authenticated this request.`
       );

--- a/lib/templates/security.js
+++ b/lib/templates/security.js
@@ -1,25 +1,29 @@
 module.exports = data => {
 
-    let securitySchemes;
-    if (data.generic.securityDefinitions) {
-        securitySchemes = Object.entries(data.generic.securityDefinitions);
-    } else if (data.generic.components && data.generic.components.securitySchemes) {
-        securitySchemes = Object.entries(data.generic.components.securitySchemes);
-    } else {
-        securitySchemes = [];
-    }
-    
-    return `// implementation of the security schemes in the openapi specification
+  let securitySchemes;
+  if (data.securitySchemes) {
+    securitySchemes = Object.entries(data.securitySchemes);
+  }
+  else {
+    securitySchemes = [];
+  }
+
+  return `// implementation of the security schemes in the openapi specification
 
 class Security {
   constructor() {}
 
+  initialize(schemes){
+    // schemes will contain securitySchemes as found in the openapi specification
+    console.log("Initialize:", JSON.stringify(schemes));
+  }
+
 ${securitySchemes
-  .map(
-    ([schemeKey, schemeVal]) => `
+      .map(
+        ([schemeKey, schemeVal]) => `
   // Security scheme: ${schemeKey}
   // Type: ${schemeVal.type}
-  async ${schemeKey}(req, reply) {
+  async ${schemeKey}(req, reply, params) {
     console.log("${schemeKey}: Authenticating request");
     
     // If validation fails: throw new Error('Could not authenticate request')
@@ -27,8 +31,8 @@ ${securitySchemes
 
     // The request object can also be mutated here (e.g. to set 'req.user')
   }`
-  )
-  .join("\n")}
+      )
+      .join("\n")}
 }
 
 module.exports = new Security();

--- a/test/security.js
+++ b/test/security.js
@@ -1,11 +1,11 @@
 class Security {
     constructor() { }
 
-    async goodAuthCheck(req, reply) {
+    async goodAuthCheck(req, reply, params) {
         // Do nothing--auth check succeeds!
     }
 
-    async failingAuthCheck(req, reply) {
+    async failingAuthCheck(req, reply, params) {
         throw 'API key was invalid or not found';
     }
 

--- a/test/service.js
+++ b/test/service.js
@@ -169,8 +169,14 @@ class Service {
 
   async testOperationSecurity(req, reply) {
     return {
-      response: "authentication succeeded!"
-    }
+      response: req.scope || "authentication succeeded!"
+    };
+  }
+  
+  async testOperationSecurityWithParameter(req, reply) {
+    return {
+      response: req.scope || "authentication succeeded!"
+    };
   }
 }
 

--- a/test/test-openapi.v3.json
+++ b/test/test-openapi.v3.json
@@ -229,6 +229,45 @@
         }
       }
     },
+    "/operationSecurityWithParameter": {
+      "get": {
+        "operationId": "testOperationSecurityWithParameter",
+        "summary": "Test security handling",
+        "security": [
+          {
+            "api_key": []
+          },
+          {
+            "skipped": ["skipped"]
+          },
+          {
+            "failing": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/responseObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/errorObject"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/operationSecurityEmptyHandler": {
       "get": {
         "operationId": "testOperationSecurity",

--- a/test/test-plugin.v2.js
+++ b/test/test-plugin.v2.js
@@ -249,7 +249,6 @@ test("full pet store V2 definition does not throw error ", t => {
   fastify.register(fastifyOpenapiGlue, petStoreOpts);
   fastify.ready(err => {
     if (err) {
-      console.error(err);
       t.fail("got unexpected error");
     } else {
       t.pass("no unexpected error");

--- a/test/test-plugin.v3.js
+++ b/test/test-plugin.v3.js
@@ -427,7 +427,6 @@ test("full pet store V3 definition does not throw error ", t => {
   fastify.register(fastifyOpenapiGlue, petStoreOpts);
   fastify.ready(err => {
     if (err) {
-      console.error(err);
       t.fail("got unexpected error");
     } else {
       t.pass("no unexpected error");

--- a/test/test-swagger-noBasePath.v2.checksums.json
+++ b/test/test-swagger-noBasePath.v2.checksums.json
@@ -10,7 +10,7 @@
     },
     "security": {
       "fileName": "security.js",
-      "checksum": "cf620fa3afeb9c65cc0a031572c8dbc516e28edabca6d8f0da55cb32418ba422"
+      "checksum": "1d7e91be0b10637c8486ed6613ca1d3780d98e5b5dd3ba1e8f66f97d57d6fc63"
     },
     "plugin": {
       "fileName": "index.js",

--- a/test/test-swagger.v2.checksums.json
+++ b/test/test-swagger.v2.checksums.json
@@ -2,15 +2,15 @@
   "files": {
     "spec": {
       "fileName": "openApi.json",
-      "checksum": "02ee7f9f7d9be516ee4965696a64eca05af5a8417a2dad3d8b01ea471eaea86f"
+      "checksum": "f8eef3cb60ff6423a1fde88a2aa011ac09a511b83caa50dab25770f5fa287a78"
     },
     "service": {
       "fileName": "service.js",
-      "checksum": "e21719619a36974cac78aaa8c3a1ce90a1a59321ef778fd07e411a89277ce296"
+      "checksum": "9777584bb1e29ade79b7294e76f460dc6b40fbddff4cb66f1b34149d09270939"
     },
     "security": {
       "fileName": "security.js",
-      "checksum": "415d7020c589c9dfdc1091ba7fdfde63b6e7e4af631744e509614c2d74ff3931"
+      "checksum": "352cd162d3d78196089dc52a1e25d6c6cc21d890499ef11dbe51abbefc9fe7b0"
     },
     "plugin": {
       "fileName": "index.js",
@@ -26,7 +26,7 @@
     },
     "testPlugin": {
       "fileName": "test-plugin.js",
-      "checksum": "33e647f9d6ecb0632bcf116596456364d71630c30b3ff48e63ad0a0e094ca15e"
+      "checksum": "8b8347faba619a8678b070717c581f754d1989be02b05de11cda81ea30af5573"
     }
   }
 }

--- a/test/test-swagger.v2.json
+++ b/test/test-swagger.v2.json
@@ -172,8 +172,34 @@
           }
         }
       }
+    },
+    "/operationSecurityWithParameter": {
+      "get": {
+        "operationId": "testOperationSecurityWithParameter",
+        "summary": "Test security handling",
+        "security": [
+          { "api_key": [] },
+          { "skipped": ["skipped"] },
+          { "failing": [] }
+        ],
+        "responses": {
+          "200": {
+            "description": "ok",
+            "schema": {
+              "$ref": "#/definitions/responseObject"
+            }
+          },
+          "401": {
+            "description": "unauthorized",
+            "schema": {
+              "$ref": "#/definitions/errorObject"
+            }
+          }
+        }
+      }
     }
   },
+  
   "definitions": {
     "bodyObject": {
       "type": "object",


### PR DESCRIPTION
You can specify your own securityHandlers with the `securityHandlers` option.
If the provided object has an `initialize` function then fastify-openapi-glue will call this function with the `/components/securitySchemes` property (v3) or the `/securityDefinitions` property (v2) of the specification provided.

### Example

In the petstore example specification there is a section:
```json
"/pet": {
      "post": {
       ...
        "summary": "Add a new pet to the store",
        "description": "",
        "operationId": "addPet",
        ...
        "security": [
          {
            "petstore_auth": [
              "write:pets",
              "read:pets"
            ]
          }
        ],
```

If you provide a securityHandler called `petstore_auth` then it will be called as `petstore_auth(request,reply, params)` where request and reply will be fastify request and reply objects and params contains `["write:pets", "read:pets"]`.