### PR TITLE
Add ES6 module support

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "types": "index.d.ts",
   "scripts": {
     "start": "fastify start examples/petstore/index.js",
-    "test": "tap test/test-*.js",
+    "test": "tap --no-esm test/test-*.js",
     "covtest": "tap test/test-*.js --coverage-report=html",
     "dev": "fastify start -l info -P examples/petstore/index.js",
     "updateChecksums": "node bin/openapi-glue-cli -c test/test-swagger.v2.json > test/test-swagger.v2.checksums.json",

--- a/test/service.mjs
+++ b/test/service.mjs
@@ -1,0 +1,203 @@
+// ES6 Module implementation of the operations in the openapi specification
+
+class Service {
+  constructor() {}
+
+  // Operation: getPathParam
+  // summary:  Test path parameters
+  // req.params:
+  //   type: object
+  //   properties:
+  //     id:
+  //       type: integer
+  //   required:
+  //     - id
+  //
+  // valid responses:
+  //   '200':
+  //     description: ok
+  //
+
+  async getPathParam(req, reply) {
+    if (typeof req.params.id !== "number") {
+      throw new Error("req.params.id is not a number");
+    }
+    return "";
+  }
+
+  // Operation: getQueryParam
+  // summary:  Test query parameters
+  // req.query:
+  //   type: object
+  //   properties:
+  //     int1:
+  //       type: integer
+  //     int2:
+  //       type: integer
+  //
+  // valid responses:
+  //   '200':
+  //     description: ok
+  //
+
+  async getQueryParam(req, reply) {
+    if (
+      typeof req.query.int1 !== "number" ||
+      typeof req.query.int2 !== "number"
+    ) {
+      throw new Error("req.params.int1 or req.params.int2 is not a number");
+    }
+    return "";
+  }
+
+  // Operation: getHeaderParam
+  // summary:  Test header parameters
+  // req.headers:
+  //   type: object
+  //   properties:
+  //     X-Request-ID:
+  //       type: string
+  //
+  // valid responses:
+  //   '200':
+  //     description: ok
+  //
+
+  async getHeaderParam(req, reply) {
+    if (typeof req.headers["x-request-id"] !== "string") {
+      throw new Error("req.header['x-request-id'] is not a string");
+    }
+    return "";
+  }
+
+  // Operation: getAuthHeaderParam
+  // summary:  Test authorization header parameters
+  // req.headers:
+  //   type: object
+  //   properties:
+  //     authorization:
+  //       type: string
+  //
+  // valid responses:
+  //   '200':
+  //     description: ok
+  //
+
+  async getAuthHeaderParam(req, reply) {
+    if (typeof req.headers["authorization"] !== "string") {
+      throw new Error("req.header['authorization'] is not a string");
+    }
+    return "";
+  }
+
+  // Operation: getNoParam
+  // summary:  Test no parameters
+  //
+  // valid responses:
+  //   '200':
+  //     description: ok
+  //
+
+  async getNoParam(req, reply) {
+    return "";
+  }
+
+  // Operation: postBodyParam
+  // summary:  Test body parameters
+  // req.body:
+  //   type: string
+  //
+  // valid responses:
+  //   '200':
+  //     description: ok
+  //
+
+  async postBodyParam(req, reply) {
+    if (typeof req.body.str1 !== "string") {
+      throw new Error("req.body.str1 is not a string");
+    }
+    return "";
+  }
+
+  // Operation: getResponse
+  // summary:  Test response serialization
+  // req.query:
+  //   type: object
+  //   properties:
+  //     respType:
+  //       type: string
+  //
+  // valid responses:
+  //   '200':
+  //     description: ok
+  //     schema:
+  //       type: object
+  //       properties:
+  //         response:
+  //           type: string
+  //       required:
+  //         - response
+  //
+
+  async getResponse(req, reply) {
+    if (req.query.replyType === "valid") {
+      return { response: "test data" };
+    } else {
+      return { invalid: 1 };
+    }
+  }
+
+  // Operation: testOperationSecurity
+  // summary:  Test response serialization
+  // req.query:
+  //   type: object
+  //   properties:
+  //     respType:
+  //       type: string
+  //
+  // valid responses:
+  //   '200':
+  //     description: ok
+  //     schema:
+  //       type: object
+  //       properties:
+  //         response:
+  //           type: string
+  //       required:
+  //         - response
+  //
+
+  async testOperationSecurity(req, reply) {
+    return {
+      response: req.scope || "authentication succeeded!"
+    };
+  }
+
+  // Operation: testOperationSecurityWithParameter
+  // summary:  Test response serialization
+  // req.query:
+  //   type: object
+  //   properties:
+  //     respType:
+  //       type: string
+  //
+  // valid responses:
+  //   '200':
+  //     description: ok
+  //     schema:
+  //       type: object
+  //       properties:
+  //         response:
+  //           type: string
+  //       required:
+  //         - response
+  //
+  
+  async testOperationSecurityWithParameter(req, reply) {
+    return {
+      response: req.scope || "authentication succeeded!"
+    };
+  }
+}
+
+export default opts => new Service(opts);

--- a/test/test-plugin.v3.js
+++ b/test/test-plugin.v3.js
@@ -2,6 +2,7 @@ const t = require("tap");
 const test = t.test;
 const Fastify = require("fastify");
 const fastifyOpenapiGlue = require("../index");
+const hasESM = process.version.split(/[v|\./]/)[1] >= 14;
 
 const testSpec = require("./test-openapi.v3.json");
 const petStoreSpec = require("./petstore-openapi.v3.json");
@@ -48,6 +49,11 @@ const missingServiceOpts = {
 const asyncServiceOpts = {
   specification: testSpec,
   service: `${__dirname}/async-service.js`
+};
+
+const ES6ServiceOpts = {
+  specification: testSpec,
+  service: `${__dirname}/service.mjs`
 };
 
 const petStoreOpts = {
@@ -415,6 +421,24 @@ test("async service definition does not throw error", t => {
     }
   );
 });
+
+if (hasESM) {
+  test("ES6 service definition does not throw error", t => {
+    t.plan(2);
+    const fastify = Fastify();
+    fastify.register(fastifyOpenapiGlue, ES6ServiceOpts);
+    fastify.inject(
+      {
+        method: "GET",
+        url: "/pathParam/2"
+      },
+      (err, res) => {
+        t.error(err);
+        t.strictEqual(res.statusCode, 200);
+      }
+    );
+  });
+}
 
 test("full pet store V3 definition does not throw error ", t => {
   t.plan(1);


### PR DESCRIPTION
This PR adds ES6 Module support.

You can now use ES6 modules for `service`  and `securityHandlers` if you are using Nodejs >= 14