### PR TITLE
add support for exploding querystring parameter

### DIFF
--- a/lib/Parser.v3.js
+++ b/lib/Parser.v3.js
@@ -12,9 +12,25 @@ const HttpOperations = new Set([
   "options",
 ]);
 
+const explodingTypes = new Set([
+  "object",
+  "array"
+])
+
 export class ParserV3 extends ParserBase {
   constructor() {
     super(); // Now 'this' is initialized by calling the parent constructor.
+  }
+
+  parseQueryString(data) {
+    if ((data.length === 1)
+      && (data[0].explode !== false)
+      && (typeof data[0].schema === "object")
+      && explodingTypes.has(data[0].schema.type)) {
+      return data[0].schema
+    }
+    return this.parseParams(data)
+
   }
 
   parseParams(data) {
@@ -64,7 +80,7 @@ export class ParserV3 extends ParserBase {
     });
     if (params.length > 0) schema.params = this.parseParams(params);
     if (querystring.length > 0)
-      schema.querystring = this.parseParams(querystring);
+      schema.querystring = this.parseQueryString(querystring);
     if (headers.length > 0) schema.headers = this.parseParams(headers);
   }
 
@@ -95,8 +111,8 @@ export class ParserV3 extends ParserBase {
     this.copyProps(data, schema, copyItems, true);
     if (data.parameters) this.parseParameters(schema, data.parameters);
     const body = this.parseBody(data.requestBody);
-    if (body) { 
-      schema.body = body 
+    if (body) {
+      schema.body = body
     };
     const response = this.parseResponses(data.responses);
     if (Object.keys(response).length > 0) {

--- a/test/service.js
+++ b/test/service.js
@@ -50,6 +50,31 @@ class Service {
     return "";
   }
 
+    // Operation: getQueryParam
+  // summary:  Test query parameters
+  // req.query:
+  //   type: object
+  //   properties:
+  //     int1:
+  //       type: integer
+  //     int2:
+  //       type: integer
+  //
+  // valid responses:
+  //   '200':
+  //     description: ok
+  //
+
+  async getQueryParamObject(req, reply) {
+    if (
+      typeof req.query.int1 !== "number" ||
+      typeof req.query.int2 !== "number"
+    ) {
+      throw new Error("req.params.int1 or req.params.int2 is not a number");
+    }
+    return "";
+  }
+
   // Operation: getHeaderParam
   // summary:  Test header parameters
   // req.headers:

--- a/test/test-openapi.v3.json
+++ b/test/test-openapi.v3.json
@@ -47,14 +47,48 @@
             "name": "int1",
             "schema": {
               "type": "integer"
-            }
+            },
+            "required":true
           },
           {
             "in": "query",
             "name": "int2",
             "schema": {
               "type": "integer"
-            }
+            },
+            "required":true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ok"
+          }
+        },
+        "x-tap-ok": true
+      }
+    },
+    "/queryParamObject": {
+      "get": {
+        "operationId": "getQueryParamObject",
+        "summary": "Test query parameters in an object",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "obj",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "int1":
+                {
+                  "type": "integer"
+                },
+                "int2": {
+                  "type": "integer"
+                }
+              },
+              "required":["int1","int2"]
+            },
+            "required":true
           }
         ],
         "responses": {

--- a/test/test-plugin.v3.js
+++ b/test/test-plugin.v3.js
@@ -115,6 +115,24 @@ test("query parameters work", t => {
   );
 });
 
+test("query parameters with object schema work", t => {
+  t.plan(2);
+  const fastify = Fastify();
+  fastify.register(fastifyOpenapiGlue, opts);
+
+  fastify.inject(
+    {
+      method: "GET",
+      url: "/queryParamObject?int1=1&int2=2"
+    },
+    (err, res) => {
+      console.log(res.body)
+      t.error(err);
+      t.equal(res.statusCode, 200);
+    }
+  );
+});
+
 test("header parameters work", t => {
   t.plan(2);
   const fastify = Fastify();


### PR DESCRIPTION
This PR adds support for "explode" property on "in:query" parameters
As [per specification](https://spec.openapis.org/oas/v3.1.0#fixed-fields-9): 

explode | boolean | When this is true, parameter values of type array or object generate separate parameters for each value of the array or key-value pair of the map. For other types of parameters this property has no effect. When style is form, the default value is true. For all other styles, the default value is false.
-- | -- | --

The specification is not very clear on what the "For other types of parameters this property has no effect. " means.
For now we assume it only applies to "in:query" as that would make most sense.


 