### PR TITLE
Fix parsing error if there are no mime types specified.

### DIFF
--- a/lib/Parser.v3.js
+++ b/lib/Parser.v3.js
@@ -88,6 +88,9 @@ export class ParserV3 extends ParserBase {
     if (data && data.content) {
       const mimeTypes = Object.keys(data.content)
       mimeTypes.forEach(mimeType => this.config.contentTypes.add(mimeType));
+      if (mimeTypes.length === 0) {
+        return undefined;
+      }
       // fastify only supports one mimeType per path, pick the last
       return data.content[mimeTypes.pop()].schema;
     }


### PR DESCRIPTION
Generating a schema where there isn't a mime type specified for a Body section would fail with this exception.

```
Cannot read property 'schema' of undefined
```

This change fixes that problem.