### PR TITLE
feat: rich parameters.

### DIFF
--- a/index.js
+++ b/index.js
@@ -121,7 +121,7 @@ async function fastifyOpenapiGlue(instance, opts) {
         stripResponseFormats(response);
       }
       if (item.operationId in service) {
-        routesInstance.log.debug("service has", item.operationId);
+        routesInstance.log.debug("service has %s", item.operationId);
         item.handler = service[item.operationId].bind(service);
       } else {
         item.handler = notImplemented(item.operationId);

--- a/lib/paramUtils.js
+++ b/lib/paramUtils.js
@@ -1,0 +1,36 @@
+function setProperty(ob, path, value) {
+  const key = path[0];
+  if (path.length === 1) {
+    ob[key] = value;
+  } else {
+    // If the next key is a number, assume that we should construct an array.
+    //   "foo[0][a]=1" -> { foo: [{ a: 1 }] }
+    // This is usually, but not necessarily, correct, since
+    //   "foo[0][a]=1" -> { foo: { '0': { a: 1 } } }
+    // is also possible. But ajv will throw validation errors if a supposed
+    // array comes back as an object, and if we have to guess, this is safer.
+    // (An ideal approach would use the JSON schema.)
+    let nextKey = path[1];
+    if (/^\d+$/.test(nextKey)) nextKey = Number(nextKey);
+    if (!(key in ob)) ob[key] = typeof nextKey === "number" ? [] : {};
+    setProperty(ob[key], path.slice(1), value);
+  }
+}
+
+exports.mergeDeepObjectParam = function mergeDeepObjectParam(ob, name) {
+  for (const key of Object.keys(ob)) {
+    if (!key.startsWith(`${name}[`)) {
+      continue;
+    }
+
+    const rest = key.substr(name.length);
+    if (/^(\[\w+])+/.test(rest)) {
+      const keys = rest
+        .substr(0, rest.length - 1)
+        .split("]")
+        .map((s) => s.substr(1));
+      setProperty(ob, [name, ...keys], ob[key]);
+      delete ob[key];
+    }
+  }
+};

--- a/lib/parser.v3.js
+++ b/lib/parser.v3.js
@@ -40,7 +40,12 @@ class parserV3 extends parserBase {
     };
     const required = [];
     data.forEach((item) => {
-      params.properties[item.name] = item.schema;
+      if (item.content && item.content['application/json']) {
+        params.properties[item.name] = item.content['application/json'].schema;
+      } else {
+        params.properties[item.name] = item.schema;
+      }
+
       this.copyProps(item, params.properties[item.name], ["description"]);
       // ajv wants "required" to be an array, which seems to be too strict
       // see https://github.com/json-schema/json-schema/wiki/Properties-and-required

--- a/test/test-params.js
+++ b/test/test-params.js
@@ -1,0 +1,32 @@
+const t = require("tap");
+const mergeDeepObjectParam = require("../lib/paramUtils").mergeDeepObjectParam;
+
+t.test("deepObject parameters are correctly extracted", (t) => {
+  t.plan(2);
+  const ob = {
+    "one[two][three]": 1,
+    "four[five][six]": 2,
+  };
+  mergeDeepObjectParam(ob, "one");
+  t.same(
+    ob,
+    { one: { two: { three: 1 } }, "four[five][six]": 2 },
+    "selected deepObject parameters are extracted"
+  );
+  mergeDeepObjectParam(ob, "four");
+  t.same(
+    ob,
+    { one: { two: { three: 1 } }, four: { five: { six: 2 } } },
+    "all deepObject parameters are extracted"
+  );
+});
+
+t.test("deepObject restores array type", (t) => {
+  t.plan(2);
+  const ob = {
+    "arr[0]": 1,
+  };
+  mergeDeepObjectParam(ob, "arr");
+  t.ok(Array.isArray(ob.arr), "deepObject preserves array type");
+  t.same(ob, { arr: [1] }, "deepObject parameters are extracted");
+});


### PR DESCRIPTION
Add support for two aspects of OpenAPI parameter specifications:

1. Parameters declared with `{ "style": "deepObject" }` like ` "?foo[bar][baz]=1".`
2. Parameters with `"content"` and media type `"application/json"` rather than simple `"schema"`.

(There are more parameter styles also not supported, AFAICT.)