### PR TITLE
fix(log): blank operation in log on fastify v3

### DIFF
--- a/index.js
+++ b/index.js
@@ -131,7 +131,7 @@ async function fastifyOpenapiGlue(instance, opts) {
         stripResponseFormats(response);
       }
       if (item.operationId in service) {
-        routesInstance.log.debug("service has %j", item.operationId);
+        routesInstance.log.debug(`service has '${item.operationId}'`);
         item.handler = service[item.operationId].bind(service);
       } else {
         item.handler = notImplemented(item.operationId);

--- a/lib/securityHandlers.js
+++ b/lib/securityHandlers.js
@@ -55,7 +55,7 @@ export default class Security {
           await securityHandlers[scheme.name](req, reply, scheme.parameters);
           return; // If one security check passes, no need to try any others
         } catch (err) {
-          req.log.debug("Security check failed:", err, err.stack);
+          req.log.debug(`Security check failed: ${err.stack}`);
           handlerErrors.push(err);
         }
         schemeList.push(scheme.name);


### PR DESCRIPTION
Fastify v3 upgrades Pino to v6, which has some breaking changes in terms of how the logging interface handles additional parameters. String templating is now required using the sprintf format.