### PR TITLE
Fix: use FastifyPluginAsync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 ### Changed
  - Migrated to ES Modules format
 
+## [2.7.2] - 07-06-2022
+ - Fix Typescript definition
+
 ## [2.7.1] - 06-06-2022
  - Fix 'defaultAJV' option
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="node" />
 
-import { FastifyRegister } from "fastify";
+import { FastifyPluginAsync } from "fastify";
 
 
 export interface FastifyOpenapiGlueOptions {
@@ -14,6 +14,6 @@ export interface FastifyOpenapiGlueOptions {
 }
 
 
-declare const FastifyOpenApiGlue: FastifyRegister<FastifyOpenapiGlueOptions>;
+declare const FastifyOpenApiGlue: FastifyPluginAsync<FastifyOpenapiGlueOptions>;
 
 export default FastifyOpenApiGlue;


### PR DESCRIPTION
Fix the typescript definition that was changed incorrectly in 2.7.0