### PR TITLE
feat(route): allow passing route config in api spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,29 @@ See the [examples](#examples) section for a demo.
 
 Please be aware that `this` will refer to your service object or your securityHandler object and not to Fastify as explained in the [bindings documentation](docs/bindings.md)
 
+<a name="pluginApiExtensions"></a>
+### OpenAPI extensions
+The OpenAPI specification supports [extending an API spec](https://swagger.io/docs/specification/openapi-extensions/) to describe extra functionality that isn't covered by the official specification. Extensions start with `x-` (e.g., `x-myapp-logo`) and can contain a primitive, an array, an object, or `null`.
+
+The following extensions are provided by the plugin:
+- `x-fastify-config` (object): any properties will be added to the `routeOptions.config` / `context.config` property of the Fastify route.
+
+  For example, if you wanted to use the fastify-raw-body plugin to compute a checksum of the request body, you could add the following extension to your OpenAPI spec to signal the plugin to specially handle this route:
+
+  ```yaml
+  paths:
+    /webhooks:
+      post:
+        operationId: processWebhook
+        x-fastify-config:
+          rawBody: true
+        responses:
+          204:
+            description: Webhook processed successfully
+  ```
+
+You can also set custom OpenAPI extensions (e.g., `x-myapp-foo`) for use within your app's implementation. These properties are passed through unmodified to the Fastify route on `{req,reply}.context`. Extensions specified on a schema are also accessible (e.g., `context.schema.body` or `context.schema.responses[<statusCode>]`).
+
 <a name="generator"></a>
 ## Generator
 

--- a/lib/Parser.v2.js
+++ b/lib/Parser.v2.js
@@ -106,6 +106,11 @@ export class ParserV2 extends ParserBase {
       openapiSource: data,
       security: this.parseSecurity(data.security || this.spec.security),
     };
+
+    if (data['x-fastify-config']) {
+      route.config = data['x-fastify-config'];
+    }
+
     this.config.routes.push(route);
   }
 

--- a/lib/Parser.v3.js
+++ b/lib/Parser.v3.js
@@ -136,6 +136,11 @@ export class ParserV3 extends ParserBase {
         operationSpec.security || this.spec.security
       ),
     };
+
+    if (operationSpec['x-fastify-config']) {
+      route.config = operationSpec['x-fastify-config'];
+    }
+
     this.config.routes.push(route);
   }
 

--- a/test/test-openapi.v3.json
+++ b/test/test-openapi.v3.json
@@ -351,6 +351,27 @@
           }
         }
       }
+    },
+    "/operationWithFastifyConfigExtension": {
+      "get": {
+        "operationId": "operationWithFastifyConfigExtension",
+        "summary": "Test fastify config extension",
+        "x-fastify-config": {
+          "rawBody": true
+        },
+        "responses": {
+          "200": {
+            "description": "ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/responseObject"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {

--- a/test/test-plugin.v2.js
+++ b/test/test-plugin.v2.js
@@ -291,3 +291,27 @@ test("x- props are copied", t => {
     }
   );
 });
+
+test("x-fastify-config is applied", t => {
+  t.plan(1);
+  const fastify = Fastify();
+  fastify.register(fastifyOpenapiGlue, {
+    ...opts,
+    service: {
+      operationWithFastifyConfigExtension: (req, reply) => {
+        t.equal(req.context.config.rawBody, true, "config.rawBody is true");
+        return reply;
+      }
+    }
+  });
+
+  fastify.inject(
+    {
+      method: "GET",
+      url: "/v2/operationWithFastifyConfigExtension",
+    },
+    (err, res) => {
+      t.pass();
+    }
+  );
+});

--- a/test/test-plugin.v3.js
+++ b/test/test-plugin.v3.js
@@ -460,3 +460,27 @@ test("x- props are copied", t => {
     }
   );
 });
+
+test("x-fastify-config is applied", t => {
+  t.plan(1);
+  const fastify = Fastify();
+  fastify.register(fastifyOpenapiGlue, {
+    ...opts,
+    service: {
+      operationWithFastifyConfigExtension: (req, reply) => {
+        t.equal(req.context.config.rawBody, true, "config.rawBody is true");
+        return reply;
+      }
+    }
+  });
+
+  fastify.inject(
+    {
+      method: "GET",
+      url: "/operationWithFastifyConfigExtension",
+    },
+    (err, res) => {
+      t.pass();
+    }
+  );
+});

--- a/test/test-swagger.v2.checksums.json
+++ b/test/test-swagger.v2.checksums.json
@@ -2,11 +2,11 @@
   "files": {
     "spec": {
       "fileName": "openApi.json",
-      "checksum": "4f9f1bb12dece03861911569eab227e478271d0f41ebfaab08d98bbea7197eb9"
+      "checksum": "7bb8dcb52c5469d084b886fc20174ead871cdc6ee9598a74d0f73ab67ff42f48"
     },
     "service": {
       "fileName": "service.js",
-      "checksum": "b84afa7a31aca2aaa11af9e3169302170fb181d00146db9f96567e75b4a24258"
+      "checksum": "fb7781fce43d5577135923f86ceda476d50850ee66d4606dcf1177d410b1d311"
     },
     "security": {
       "fileName": "security.js",
@@ -26,7 +26,7 @@
     },
     "testPlugin": {
       "fileName": "test-plugin.js",
-      "checksum": "788e8f0990d9689018fcd48980ec13e30b5f73f185b0cc87e0909ec2b3a04ce1"
+      "checksum": "1f8bae23fab818affac0d08283877bc3455dfa9fb430e2cf0d64e1b2230e1520"
     }
   }
 }

--- a/test/test-swagger.v2.json
+++ b/test/test-swagger.v2.json
@@ -220,6 +220,23 @@
           }
         }
       }
+    },
+    "/operationWithFastifyConfigExtension": {
+      "get": {
+        "operationId": "operationWithFastifyConfigExtension",
+        "summary": "Test fastify config extension",
+        "x-fastify-config": {
+          "rawBody": true
+        },
+        "responses": {
+          "200": {
+            "description": "ok",
+            "schema": {
+              "$ref": "#/definitions/responseObject"
+            }
+          }
+        }
+      }
     }
   },
   "definitions": {


### PR DESCRIPTION
I recently came across a scenario where being able to add things to a route's `config` property from the API spec would be useful. (My case was specifically regarding the use of [fastify-raw-body](https://github.com/Eomm/fastify-raw-body).)

I implemented this as an extension `x-fastify-config` that can be added to an operation spec. I still need to update the readme as part of this PR, but wanted to get any feedback on whether this is something the community feels is beneficial as well as whether the approach is acceptable.