### PR TITLE
Fix/skip security if schemes empty

### DIFF
--- a/lib/securityHandlers.js
+++ b/lib/securityHandlers.js
@@ -12,7 +12,7 @@ export default class Security {
   }
 
   has(schemes) {
-    if (!schemes) {
+    if (!(schemes?.length > 0)) {
       return false;
     }
     const mapKey = JSON.stringify(schemes);

--- a/test/test-openapi.v3.json
+++ b/test/test-openapi.v3.json
@@ -48,7 +48,7 @@
             "schema": {
               "type": "integer"
             },
-            "required":true
+            "required": true
           },
           {
             "in": "query",
@@ -56,7 +56,7 @@
             "schema": {
               "type": "integer"
             },
-            "required":true
+            "required": true
           }
         ],
         "responses": {
@@ -78,17 +78,19 @@
             "schema": {
               "type": "object",
               "properties": {
-                "int1":
-                {
+                "int1": {
                   "type": "integer"
                 },
                 "int2": {
                   "type": "integer"
                 }
               },
-              "required":["int1","int2"]
+              "required": [
+                "int1",
+                "int2"
+              ]
             },
-            "required":true
+            "required": true
           }
         ],
         "responses": {
@@ -288,7 +290,9 @@
             "api_key": []
           },
           {
-            "skipped": ["skipped"]
+            "skipped": [
+              "skipped"
+            ]
           },
           {
             "failing": []
@@ -345,6 +349,25 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/errorObject"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/operationSecurityOverrideWithNoSecurity": {
+      "get": {
+        "operationId": "testOperationSecurity",
+        "summary": "Test security handling",
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/responseObject"
                 }
               }
             }


### PR DESCRIPTION
As you likely expected, my initial goal ;)

### Changed (Openapi V3)
- Fix: skip security checks if `schemes` array is empty (or undefined)

### Added (Openapi V3)
- Test: add test case for fix above

Related to https://github.com/seriousme/fastify-openapi-glue/issues/371