### PR TITLE
Fix fastify test warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 ## [Unreleased]
 ### Changed
 
+## [4.0.3] - 18-10-2022
+### Changed
+ - fix: remove FSTDEP012 warnings caused by test cases 
+ - updated dependencies:
+    - @seriousme/openapi-schema-validator   ^2.0.3  →   ^2.1.0
+    - eslint                               ^8.23.0  →  ^8.25.0
+    - fastify                               ^4.5.3  →   ^4.9.2
+    - fastify-cli                           ^5.4.1  →   ^5.5.0
+    - fastify-plugin                        ^4.2.1  →   ^4.3.0
+    - minimist                              ^1.2.6  →   ^1.2.7
+
 ## [4.0.2] - 07-10-2022
 ### Changed
  - fix: add default export to package.json

--- a/examples/generatedProject/package.json
+++ b/examples/generatedProject/package.json
@@ -12,18 +12,18 @@
     "test": "test"
   },
   "dependencies": {
-    "fastify-plugin": "^4.2.1",
-    "@seriousme/openapi-schema-validator": "^2.0.3",
+    "fastify-plugin": "^4.3.0",
+    "@seriousme/openapi-schema-validator": "^2.1.0",
     "js-yaml": "^4.1.0",
-    "minimist": "^1.2.6",
-    "fastify-openapi-glue": "^4.0.1"
+    "minimist": "^1.2.7",
+    "fastify-openapi-glue": "^4.0.2"
   },
   "devDependencies": {
-    "fastify": "^4.5.3",
-    "fastify-cli": "^5.4.1",
+    "fastify": "^4.9.2",
+    "fastify-cli": "^5.5.0",
     "tap": "^16.3.0",
     "c8": "^7.12.0",
-    "eslint": "^8.23.0",
+    "eslint": "^8.25.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-prettier": "^4.2.1",
     "husky": "^8.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,21 +9,21 @@
       "version": "4.0.2",
       "license": "MIT",
       "dependencies": {
-        "@seriousme/openapi-schema-validator": "^2.0.3",
-        "fastify-plugin": "^4.2.1",
+        "@seriousme/openapi-schema-validator": "^2.1.0",
+        "fastify-plugin": "^4.3.0",
         "js-yaml": "^4.1.0",
-        "minimist": "^1.2.6"
+        "minimist": "^1.2.7"
       },
       "bin": {
         "openapi-glue": "bin/openapi-glue-cli.js"
       },
       "devDependencies": {
         "c8": "^7.12.0",
-        "eslint": "^8.23.0",
+        "eslint": "^8.25.0",
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-prettier": "^4.2.1",
-        "fastify": "^4.5.3",
-        "fastify-cli": "^5.4.1",
+        "fastify": "^4.9.2",
+        "fastify-cli": "^5.5.0",
         "husky": "^8.0.1",
         "lint-staged": "^13.0.3",
         "prettier": "2.7.1",
@@ -2110,9 +2110,9 @@
       "dev": true
     },
     "node_modules/fastify": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/fastify/-/fastify-4.9.1.tgz",
-      "integrity": "sha512-n5e3TSO8Wzc8kw8bZoF+ydTbbU9pq0eXNciEAqewa7kwHZQM4o9lRcgZeh7R9IhDSiOuII2kT8Q00y6Cnj7HPg==",
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/fastify/-/fastify-4.9.2.tgz",
+      "integrity": "sha512-Mk3hv7ZRet2huMYN6IJ8RGy1TAAC7LJsCEjxLf808zafAADNu43xRzbl7FSEIBxKyhntTM0F626Oc34LUNcUxQ==",
       "dev": true,
       "dependencies": {
         "@fastify/ajv-compiler": "^3.3.1",
@@ -8674,9 +8674,9 @@
       "dev": true
     },
     "fastify": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/fastify/-/fastify-4.9.1.tgz",
-      "integrity": "sha512-n5e3TSO8Wzc8kw8bZoF+ydTbbU9pq0eXNciEAqewa7kwHZQM4o9lRcgZeh7R9IhDSiOuII2kT8Q00y6Cnj7HPg==",
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/fastify/-/fastify-4.9.2.tgz",
+      "integrity": "sha512-Mk3hv7ZRet2huMYN6IJ8RGy1TAAC7LJsCEjxLf808zafAADNu43xRzbl7FSEIBxKyhntTM0F626Oc34LUNcUxQ==",
       "dev": true,
       "requires": {
         "@fastify/ajv-compiler": "^3.3.1",

--- a/package.json
+++ b/package.json
@@ -27,10 +27,10 @@
     "openapi-glue": "./bin/openapi-glue-cli.js"
   },
   "dependencies": {
-    "@seriousme/openapi-schema-validator": "^2.0.3",
-    "fastify-plugin": "^4.2.1",
+    "@seriousme/openapi-schema-validator": "^2.1.0",
+    "fastify-plugin": "^4.3.0",
     "js-yaml": "^4.1.0",
-    "minimist": "^1.2.6"
+    "minimist": "^1.2.7"
   },
   "directories": {
     "example": "./examples",
@@ -40,11 +40,11 @@
   },
   "devDependencies": {
     "c8": "^7.12.0",
-    "eslint": "^8.23.0",
+    "eslint": "^8.25.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-prettier": "^4.2.1",
-    "fastify": "^4.5.3",
-    "fastify-cli": "^5.4.1",
+    "fastify": "^4.9.2",
+    "fastify-cli": "^5.5.0",
     "husky": "^8.0.1",
     "lint-staged": "^13.0.3",
     "prettier": "2.7.1",

--- a/test/test-plugin.v2.js
+++ b/test/test-plugin.v2.js
@@ -301,7 +301,7 @@ test("x-fastify-config is applied", (t) => {
     ...opts,
     service: {
       operationWithFastifyConfigExtension: (req, reply) => {
-        t.equal(req.context.config.rawBody, true, "config.rawBody is true");
+        t.equal(req.routeConfig.rawBody, true, "config.rawBody is true");
         return reply;
       },
     },

--- a/test/test-plugin.v3.js
+++ b/test/test-plugin.v3.js
@@ -488,7 +488,7 @@ test("x-fastify-config is applied", (t) => {
     ...opts,
     service: {
       operationWithFastifyConfigExtension: (req, reply) => {
-        t.equal(req.context.config.rawBody, true, "config.rawBody is true");
+        t.equal(req.routeConfig.rawBody, true, "config.rawBody is true");
         return reply;
       },
     },


### PR DESCRIPTION
This PR updates dependencies and fixes
```
[FSTDEP012] FastifyDeprecation: Request#context property access is deprecated. Please use "Request#routeConfig" or "Request#routeSchema" instead for accessing Route settings. The "Request#context" will be removed in `fastify@5`.
```
warnings in test cases.