### PR TITLE
fix: change Context.schema to routeSchema

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Please be aware that `this` will refer to your service object or your securityHa
 The OpenAPI specification supports [extending an API spec](https://spec.openapis.org/oas/latest.html#specification-extensions) to describe extra functionality that isn't covered by the official specification. Extensions start with `x-` (e.g., `x-myapp-logo`) and can contain a primitive, an array, an object, or `null`.
 
 The following extensions are provided by the plugin:
-- `x-fastify-config` (object): any properties will be added to the `routeOptions.config` / `context.config` property of the Fastify route.
+- `x-fastify-config` (object): any properties will be added to the `routeOptions.config` property of the Fastify route.
 
   For example, if you wanted to use the fastify-raw-body plugin to compute a checksum of the request body, you could add the following extension to your OpenAPI spec to signal the plugin to specially handle this route:
 
@@ -77,7 +77,7 @@ The following extensions are provided by the plugin:
             description: Webhook processed successfully
   ```
 
-You can also set custom OpenAPI extensions (e.g., `x-myapp-foo`) for use within your app's implementation. These properties are passed through unmodified to the Fastify route on `{req,reply}.context`. Extensions specified on a schema are also accessible (e.g., `context.schema.body` or `context.schema.responses[<statusCode>]`).
+You can also set custom OpenAPI extensions (e.g., `x-myapp-foo`) for use within your app's implementation. These properties are passed through unmodified to the Fastify route on `{req,reply}.routeConfig`. Extensions specified on a schema are also accessible (e.g., `routeSchema.body` or `routeSchema.responses[<statusCode>]`).
 
 <a name="generator"></a>
 ## Generator

--- a/examples/generated-javascript-project/package.json
+++ b/examples/generated-javascript-project/package.json
@@ -19,7 +19,7 @@
     "fastify-openapi-glue": "^4.1.3"
   },
   "devDependencies": {
-    "fastify": "^4.14.1",
+    "fastify": "^4.17.0",
     "fastify-cli": "^5.7.1",
     "tap": "^16.3.4",
     "c8": "^7.13.0",

--- a/examples/generated-standaloneJS-project/package.json
+++ b/examples/generated-standaloneJS-project/package.json
@@ -18,7 +18,7 @@
     "minimist": "^1.2.8"
   },
   "devDependencies": {
-    "fastify": "^4.14.1",
+    "fastify": "^4.17.0",
     "fastify-cli": "^5.7.1",
     "tap": "^16.3.4",
     "c8": "^7.13.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
       },
       "devDependencies": {
         "c8": "^7.13.0",
-        "fastify": "^4.14.1",
+        "fastify": "^4.17.0",
         "fastify-cli": "^5.7.1",
         "husky": "^8.0.3",
         "rome": "^12.0.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "c8": "^7.13.0",
-    "fastify": "^4.14.1",
+    "fastify": "^4.17.0",
     "fastify-cli": "^5.7.1",
     "husky": "^8.0.3",
     "rome": "^12.0.0",

--- a/test/test-plugin.v2.js
+++ b/test/test-plugin.v2.js
@@ -274,7 +274,7 @@ test("x- props are copied", (t) => {
 	t.plan(3);
 	const fastify = Fastify();
 	fastify.addHook("preHandler", async (request, reply) => {
-		if (reply.context.schema["x-tap-ok"]) {
+		if (request.routeSchema["x-tap-ok"]) {
 			t.pass("found x- prop");
 		} else {
 			t.fail("missing x- prop");

--- a/test/test-plugin.v3.js
+++ b/test/test-plugin.v3.js
@@ -488,7 +488,7 @@ test("x- props are copied", (t) => {
 	t.plan(3);
 	const fastify = Fastify();
 	fastify.addHook("preHandler", async (request, reply) => {
-		if (reply.context.schema["x-tap-ok"]) {
+		if (request.routeSchema["x-tap-ok"]) {
 			t.pass("found x- prop");
 		} else {
 			t.fail("missing x- prop");


### PR DESCRIPTION
As discussed in #472 
Request.context will be deprecated in fastify 5.x, see:
https://github.com/fastify/fastify/blob/be137713136ba5f7bd4c22805ebc501b3412565f/lib/warnings.js#L24

This PR adjusts the docs and fixes both tests that relied on `route.context`.