### PR TITLE
Replace Tap by Node Test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 ### Changed
+ - chore: replaced Tap by Node test
 
 ## [4.2.0] 09-06-2023
 ### Changed

--- a/examples/generated-javascript-project/package.json
+++ b/examples/generated-javascript-project/package.json
@@ -16,7 +16,7 @@
     "@seriousme/openapi-schema-validator": "^2.1.0",
     "js-yaml": "^4.1.0",
     "minimist": "^1.2.8",
-    "fastify-openapi-glue": "^4.1.4"
+    "fastify-openapi-glue": "^4.2.0"
   },
   "devDependencies": {
     "fastify": "^4.17.0",

--- a/examples/generated-javascript-project/test/test-plugin.js
+++ b/examples/generated-javascript-project/test/test-plugin.js
@@ -2,7 +2,8 @@
 // running the tests directly after generation will probably fail as the parameters
 // need to be manually added.
 
-import { test } from "tap";
+import { test } from "node:test";
+import { strict as assert } from "node:assert/strict";
 import Fastify from "fastify";
 import fastifyPlugin from "../index.js";
 import service from "../service.js";
@@ -77,7 +78,6 @@ const opts = {
 //
 
 test("testing addPet", (t) => {
-	t.plan(2);
 	const fastify = Fastify();
 	fastify.register(fastifyPlugin, opts);
 
@@ -89,8 +89,8 @@ test("testing addPet", (t) => {
 			headers: undefined,
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.statusCode, 200);
+			assert.ifError(err);
+			assert.equal(res.statusCode, 200);
 		},
 	);
 });
@@ -162,7 +162,6 @@ test("testing addPet", (t) => {
 //
 
 test("testing updatePet", (t) => {
-	t.plan(2);
 	const fastify = Fastify();
 	fastify.register(fastifyPlugin, opts);
 
@@ -174,8 +173,8 @@ test("testing updatePet", (t) => {
 			headers: undefined,
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.statusCode, 200);
+			assert.ifError(err);
+			assert.equal(res.statusCode, 200);
 		},
 	);
 });
@@ -255,7 +254,6 @@ test("testing updatePet", (t) => {
 //
 
 test("testing findPetsByStatus", (t) => {
-	t.plan(2);
 	const fastify = Fastify();
 	fastify.register(fastifyPlugin, opts);
 
@@ -267,8 +265,8 @@ test("testing findPetsByStatus", (t) => {
 			headers: undefined,
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.statusCode, 200);
+			assert.ifError(err);
+			assert.equal(res.statusCode, 200);
 		},
 	);
 });
@@ -348,7 +346,6 @@ test("testing findPetsByStatus", (t) => {
 //
 
 test("testing findPetsByTags", (t) => {
-	t.plan(2);
 	const fastify = Fastify();
 	fastify.register(fastifyPlugin, opts);
 
@@ -360,8 +357,8 @@ test("testing findPetsByTags", (t) => {
 			headers: undefined,
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.statusCode, 200);
+			assert.ifError(err);
+			assert.equal(res.statusCode, 200);
 		},
 	);
 });
@@ -441,7 +438,6 @@ test("testing findPetsByTags", (t) => {
 //
 
 test("testing getPetById", (t) => {
-	t.plan(2);
 	const fastify = Fastify();
 	fastify.register(fastifyPlugin, opts);
 
@@ -453,8 +449,8 @@ test("testing getPetById", (t) => {
 			headers: undefined,
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.statusCode, 200);
+			assert.ifError(err);
+			assert.equal(res.statusCode, 200);
 		},
 	);
 });
@@ -487,7 +483,6 @@ test("testing getPetById", (t) => {
 //
 
 test("testing updatePetWithForm", (t) => {
-	t.plan(2);
 	const fastify = Fastify();
 	fastify.register(fastifyPlugin, opts);
 
@@ -499,8 +494,8 @@ test("testing updatePetWithForm", (t) => {
 			headers: undefined,
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.statusCode, 200);
+			assert.ifError(err);
+			assert.equal(res.statusCode, 200);
 		},
 	);
 });
@@ -531,7 +526,6 @@ test("testing updatePetWithForm", (t) => {
 //
 
 test("testing deletePet", (t) => {
-	t.plan(2);
 	const fastify = Fastify();
 	fastify.register(fastifyPlugin, opts);
 
@@ -543,8 +537,8 @@ test("testing deletePet", (t) => {
 			headers: undefined, //insert headers here!!
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.statusCode, 200);
+			assert.ifError(err);
+			assert.equal(res.statusCode, 200);
 		},
 	);
 });
@@ -587,7 +581,6 @@ test("testing deletePet", (t) => {
 //
 
 test("testing uploadFile", (t) => {
-	t.plan(2);
 	const fastify = Fastify();
 	fastify.register(fastifyPlugin, opts);
 
@@ -599,8 +592,8 @@ test("testing uploadFile", (t) => {
 			headers: undefined,
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.statusCode, 200);
+			assert.ifError(err);
+			assert.equal(res.statusCode, 200);
 		},
 	);
 });
@@ -619,7 +612,6 @@ test("testing uploadFile", (t) => {
 //
 
 test("testing getInventory", (t) => {
-	t.plan(2);
 	const fastify = Fastify();
 	fastify.register(fastifyPlugin, opts);
 
@@ -631,8 +623,8 @@ test("testing getInventory", (t) => {
 			headers: undefined,
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.statusCode, 200);
+			assert.ifError(err);
+			assert.equal(res.statusCode, 200);
 		},
 	);
 });
@@ -703,7 +695,6 @@ test("testing getInventory", (t) => {
 //
 
 test("testing placeOrder", (t) => {
-	t.plan(2);
 	const fastify = Fastify();
 	fastify.register(fastifyPlugin, opts);
 
@@ -715,8 +706,8 @@ test("testing placeOrder", (t) => {
 			headers: undefined,
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.statusCode, 200);
+			assert.ifError(err);
+			assert.equal(res.statusCode, 200);
 		},
 	);
 });
@@ -770,7 +761,6 @@ test("testing placeOrder", (t) => {
 //
 
 test("testing getOrderById", (t) => {
-	t.plan(2);
 	const fastify = Fastify();
 	fastify.register(fastifyPlugin, opts);
 
@@ -782,8 +772,8 @@ test("testing getOrderById", (t) => {
 			headers: undefined,
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.statusCode, 200);
+			assert.ifError(err);
+			assert.equal(res.statusCode, 200);
 		},
 	);
 });
@@ -808,7 +798,6 @@ test("testing getOrderById", (t) => {
 //
 
 test("testing deleteOrder", (t) => {
-	t.plan(2);
 	const fastify = Fastify();
 	fastify.register(fastifyPlugin, opts);
 
@@ -820,8 +809,8 @@ test("testing deleteOrder", (t) => {
 			headers: undefined,
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.statusCode, 200);
+			assert.ifError(err);
+			assert.equal(res.statusCode, 200);
 		},
 	);
 });
@@ -860,7 +849,6 @@ test("testing deleteOrder", (t) => {
 //
 
 test("testing createUser", (t) => {
-	t.plan(2);
 	const fastify = Fastify();
 	fastify.register(fastifyPlugin, opts);
 
@@ -872,8 +860,8 @@ test("testing createUser", (t) => {
 			headers: undefined,
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.statusCode, 200);
+			assert.ifError(err);
+			assert.equal(res.statusCode, 200);
 		},
 	);
 });
@@ -914,7 +902,6 @@ test("testing createUser", (t) => {
 //
 
 test("testing createUsersWithArrayInput", (t) => {
-	t.plan(2);
 	const fastify = Fastify();
 	fastify.register(fastifyPlugin, opts);
 
@@ -926,8 +913,8 @@ test("testing createUsersWithArrayInput", (t) => {
 			headers: undefined,
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.statusCode, 200);
+			assert.ifError(err);
+			assert.equal(res.statusCode, 200);
 		},
 	);
 });
@@ -968,7 +955,6 @@ test("testing createUsersWithArrayInput", (t) => {
 //
 
 test("testing createUsersWithListInput", (t) => {
-	t.plan(2);
 	const fastify = Fastify();
 	fastify.register(fastifyPlugin, opts);
 
@@ -980,8 +966,8 @@ test("testing createUsersWithListInput", (t) => {
 			headers: undefined,
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.statusCode, 200);
+			assert.ifError(err);
+			assert.equal(res.statusCode, 200);
 		},
 	);
 });
@@ -1021,7 +1007,6 @@ test("testing createUsersWithListInput", (t) => {
 //
 
 test("testing loginUser", (t) => {
-	t.plan(2);
 	const fastify = Fastify();
 	fastify.register(fastifyPlugin, opts);
 
@@ -1033,8 +1018,8 @@ test("testing loginUser", (t) => {
 			headers: undefined,
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.statusCode, 200);
+			assert.ifError(err);
+			assert.equal(res.statusCode, 200);
 		},
 	);
 });
@@ -1048,7 +1033,6 @@ test("testing loginUser", (t) => {
 //
 
 test("testing logoutUser", (t) => {
-	t.plan(2);
 	const fastify = Fastify();
 	fastify.register(fastifyPlugin, opts);
 
@@ -1060,8 +1044,8 @@ test("testing logoutUser", (t) => {
 			headers: undefined,
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.statusCode, 200);
+			assert.ifError(err);
+			assert.equal(res.statusCode, 200);
 		},
 	);
 });
@@ -1112,7 +1096,6 @@ test("testing logoutUser", (t) => {
 //
 
 test("testing getUserByName", (t) => {
-	t.plan(2);
 	const fastify = Fastify();
 	fastify.register(fastifyPlugin, opts);
 
@@ -1124,8 +1107,8 @@ test("testing getUserByName", (t) => {
 			headers: undefined,
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.statusCode, 200);
+			assert.ifError(err);
+			assert.equal(res.statusCode, 200);
 		},
 	);
 });
@@ -1175,7 +1158,6 @@ test("testing getUserByName", (t) => {
 //
 
 test("testing updateUser", (t) => {
-	t.plan(2);
 	const fastify = Fastify();
 	fastify.register(fastifyPlugin, opts);
 
@@ -1187,8 +1169,8 @@ test("testing updateUser", (t) => {
 			headers: undefined,
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.statusCode, 200);
+			assert.ifError(err);
+			assert.equal(res.statusCode, 200);
 		},
 	);
 });
@@ -1213,7 +1195,6 @@ test("testing updateUser", (t) => {
 //
 
 test("testing deleteUser", (t) => {
-	t.plan(2);
 	const fastify = Fastify();
 	fastify.register(fastifyPlugin, opts);
 
@@ -1225,8 +1206,8 @@ test("testing deleteUser", (t) => {
 			headers: undefined,
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.statusCode, 200);
+			assert.ifError(err);
+			assert.equal(res.statusCode, 200);
 		},
 	);
 });

--- a/examples/generated-standaloneJS-project/test/test-plugin.js
+++ b/examples/generated-standaloneJS-project/test/test-plugin.js
@@ -2,7 +2,8 @@
 // running the tests directly after generation will probably fail as the parameters
 // need to be manually added.
 
-import { test } from "tap";
+import { test } from "node:test";
+import { strict as assert } from "node:assert/strict";
 import Fastify from "fastify";
 import fastifyPlugin from "../index.js";
 import service from "../service.js";
@@ -77,7 +78,6 @@ const opts = {
 //
 
 test("testing addPet", (t) => {
-	t.plan(2);
 	const fastify = Fastify();
 	fastify.register(fastifyPlugin, opts);
 
@@ -89,8 +89,8 @@ test("testing addPet", (t) => {
 			headers: undefined,
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.statusCode, 200);
+			assert.ifError(err);
+			assert.equal(res.statusCode, 200);
 		},
 	);
 });
@@ -162,7 +162,6 @@ test("testing addPet", (t) => {
 //
 
 test("testing updatePet", (t) => {
-	t.plan(2);
 	const fastify = Fastify();
 	fastify.register(fastifyPlugin, opts);
 
@@ -174,8 +173,8 @@ test("testing updatePet", (t) => {
 			headers: undefined,
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.statusCode, 200);
+			assert.ifError(err);
+			assert.equal(res.statusCode, 200);
 		},
 	);
 });
@@ -255,7 +254,6 @@ test("testing updatePet", (t) => {
 //
 
 test("testing findPetsByStatus", (t) => {
-	t.plan(2);
 	const fastify = Fastify();
 	fastify.register(fastifyPlugin, opts);
 
@@ -267,8 +265,8 @@ test("testing findPetsByStatus", (t) => {
 			headers: undefined,
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.statusCode, 200);
+			assert.ifError(err);
+			assert.equal(res.statusCode, 200);
 		},
 	);
 });
@@ -348,7 +346,6 @@ test("testing findPetsByStatus", (t) => {
 //
 
 test("testing findPetsByTags", (t) => {
-	t.plan(2);
 	const fastify = Fastify();
 	fastify.register(fastifyPlugin, opts);
 
@@ -360,8 +357,8 @@ test("testing findPetsByTags", (t) => {
 			headers: undefined,
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.statusCode, 200);
+			assert.ifError(err);
+			assert.equal(res.statusCode, 200);
 		},
 	);
 });
@@ -441,7 +438,6 @@ test("testing findPetsByTags", (t) => {
 //
 
 test("testing getPetById", (t) => {
-	t.plan(2);
 	const fastify = Fastify();
 	fastify.register(fastifyPlugin, opts);
 
@@ -453,8 +449,8 @@ test("testing getPetById", (t) => {
 			headers: undefined,
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.statusCode, 200);
+			assert.ifError(err);
+			assert.equal(res.statusCode, 200);
 		},
 	);
 });
@@ -487,7 +483,6 @@ test("testing getPetById", (t) => {
 //
 
 test("testing updatePetWithForm", (t) => {
-	t.plan(2);
 	const fastify = Fastify();
 	fastify.register(fastifyPlugin, opts);
 
@@ -499,8 +494,8 @@ test("testing updatePetWithForm", (t) => {
 			headers: undefined,
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.statusCode, 200);
+			assert.ifError(err);
+			assert.equal(res.statusCode, 200);
 		},
 	);
 });
@@ -531,7 +526,6 @@ test("testing updatePetWithForm", (t) => {
 //
 
 test("testing deletePet", (t) => {
-	t.plan(2);
 	const fastify = Fastify();
 	fastify.register(fastifyPlugin, opts);
 
@@ -543,8 +537,8 @@ test("testing deletePet", (t) => {
 			headers: undefined, //insert headers here!!
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.statusCode, 200);
+			assert.ifError(err);
+			assert.equal(res.statusCode, 200);
 		},
 	);
 });
@@ -587,7 +581,6 @@ test("testing deletePet", (t) => {
 //
 
 test("testing uploadFile", (t) => {
-	t.plan(2);
 	const fastify = Fastify();
 	fastify.register(fastifyPlugin, opts);
 
@@ -599,8 +592,8 @@ test("testing uploadFile", (t) => {
 			headers: undefined,
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.statusCode, 200);
+			assert.ifError(err);
+			assert.equal(res.statusCode, 200);
 		},
 	);
 });
@@ -619,7 +612,6 @@ test("testing uploadFile", (t) => {
 //
 
 test("testing getInventory", (t) => {
-	t.plan(2);
 	const fastify = Fastify();
 	fastify.register(fastifyPlugin, opts);
 
@@ -631,8 +623,8 @@ test("testing getInventory", (t) => {
 			headers: undefined,
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.statusCode, 200);
+			assert.ifError(err);
+			assert.equal(res.statusCode, 200);
 		},
 	);
 });
@@ -703,7 +695,6 @@ test("testing getInventory", (t) => {
 //
 
 test("testing placeOrder", (t) => {
-	t.plan(2);
 	const fastify = Fastify();
 	fastify.register(fastifyPlugin, opts);
 
@@ -715,8 +706,8 @@ test("testing placeOrder", (t) => {
 			headers: undefined,
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.statusCode, 200);
+			assert.ifError(err);
+			assert.equal(res.statusCode, 200);
 		},
 	);
 });
@@ -770,7 +761,6 @@ test("testing placeOrder", (t) => {
 //
 
 test("testing getOrderById", (t) => {
-	t.plan(2);
 	const fastify = Fastify();
 	fastify.register(fastifyPlugin, opts);
 
@@ -782,8 +772,8 @@ test("testing getOrderById", (t) => {
 			headers: undefined,
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.statusCode, 200);
+			assert.ifError(err);
+			assert.equal(res.statusCode, 200);
 		},
 	);
 });
@@ -808,7 +798,6 @@ test("testing getOrderById", (t) => {
 //
 
 test("testing deleteOrder", (t) => {
-	t.plan(2);
 	const fastify = Fastify();
 	fastify.register(fastifyPlugin, opts);
 
@@ -820,8 +809,8 @@ test("testing deleteOrder", (t) => {
 			headers: undefined,
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.statusCode, 200);
+			assert.ifError(err);
+			assert.equal(res.statusCode, 200);
 		},
 	);
 });
@@ -860,7 +849,6 @@ test("testing deleteOrder", (t) => {
 //
 
 test("testing createUser", (t) => {
-	t.plan(2);
 	const fastify = Fastify();
 	fastify.register(fastifyPlugin, opts);
 
@@ -872,8 +860,8 @@ test("testing createUser", (t) => {
 			headers: undefined,
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.statusCode, 200);
+			assert.ifError(err);
+			assert.equal(res.statusCode, 200);
 		},
 	);
 });
@@ -914,7 +902,6 @@ test("testing createUser", (t) => {
 //
 
 test("testing createUsersWithArrayInput", (t) => {
-	t.plan(2);
 	const fastify = Fastify();
 	fastify.register(fastifyPlugin, opts);
 
@@ -926,8 +913,8 @@ test("testing createUsersWithArrayInput", (t) => {
 			headers: undefined,
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.statusCode, 200);
+			assert.ifError(err);
+			assert.equal(res.statusCode, 200);
 		},
 	);
 });
@@ -968,7 +955,6 @@ test("testing createUsersWithArrayInput", (t) => {
 //
 
 test("testing createUsersWithListInput", (t) => {
-	t.plan(2);
 	const fastify = Fastify();
 	fastify.register(fastifyPlugin, opts);
 
@@ -980,8 +966,8 @@ test("testing createUsersWithListInput", (t) => {
 			headers: undefined,
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.statusCode, 200);
+			assert.ifError(err);
+			assert.equal(res.statusCode, 200);
 		},
 	);
 });
@@ -1021,7 +1007,6 @@ test("testing createUsersWithListInput", (t) => {
 //
 
 test("testing loginUser", (t) => {
-	t.plan(2);
 	const fastify = Fastify();
 	fastify.register(fastifyPlugin, opts);
 
@@ -1033,8 +1018,8 @@ test("testing loginUser", (t) => {
 			headers: undefined,
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.statusCode, 200);
+			assert.ifError(err);
+			assert.equal(res.statusCode, 200);
 		},
 	);
 });
@@ -1048,7 +1033,6 @@ test("testing loginUser", (t) => {
 //
 
 test("testing logoutUser", (t) => {
-	t.plan(2);
 	const fastify = Fastify();
 	fastify.register(fastifyPlugin, opts);
 
@@ -1060,8 +1044,8 @@ test("testing logoutUser", (t) => {
 			headers: undefined,
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.statusCode, 200);
+			assert.ifError(err);
+			assert.equal(res.statusCode, 200);
 		},
 	);
 });
@@ -1112,7 +1096,6 @@ test("testing logoutUser", (t) => {
 //
 
 test("testing getUserByName", (t) => {
-	t.plan(2);
 	const fastify = Fastify();
 	fastify.register(fastifyPlugin, opts);
 
@@ -1124,8 +1107,8 @@ test("testing getUserByName", (t) => {
 			headers: undefined,
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.statusCode, 200);
+			assert.ifError(err);
+			assert.equal(res.statusCode, 200);
 		},
 	);
 });
@@ -1175,7 +1158,6 @@ test("testing getUserByName", (t) => {
 //
 
 test("testing updateUser", (t) => {
-	t.plan(2);
 	const fastify = Fastify();
 	fastify.register(fastifyPlugin, opts);
 
@@ -1187,8 +1169,8 @@ test("testing updateUser", (t) => {
 			headers: undefined,
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.statusCode, 200);
+			assert.ifError(err);
+			assert.equal(res.statusCode, 200);
 		},
 	);
 });
@@ -1213,7 +1195,6 @@ test("testing updateUser", (t) => {
 //
 
 test("testing deleteUser", (t) => {
-	t.plan(2);
 	const fastify = Fastify();
 	fastify.register(fastifyPlugin, opts);
 
@@ -1225,8 +1206,8 @@ test("testing deleteUser", (t) => {
 			headers: undefined,
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.statusCode, 200);
+			assert.ifError(err);
+			assert.equal(res.statusCode, 200);
 		},
 	);
 });

--- a/lib/templates/js/test-plugin.js
+++ b/lib/templates/js/test-plugin.js
@@ -5,7 +5,7 @@ export default (data) =>
 // running the tests directly after generation will probably fail as the parameters
 // need to be manually added.
 
-import { test } from "tap";
+import { test } from "node:test";import { strict as assert } from "node:assert/strict";
 import Fastify from "fastify";
 import fastifyPlugin from "../${data.plugin}";
 import service from "../${data.serviceFile}";
@@ -24,7 +24,7 @@ const opts = {
 // summary:	${route.schema.summary}
 ${comments(route, 0)}
 test("testing ${route.operationId}", (t) => {
-	t.plan(2);
+
 	const fastify = Fastify();
 	fastify.register(fastifyPlugin, opts);
 
@@ -40,8 +40,8 @@ test("testing ${route.operationId}", (t) => {
 			}
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.statusCode, 200);
+	assert.ifError(err);
+		assert.equal(res.statusCode, 200);
 		},
 	);
 });`,

--- a/lib/templates/standaloneJS/test-plugin.js
+++ b/lib/templates/standaloneJS/test-plugin.js
@@ -5,7 +5,7 @@ export default (data) =>
 // running the tests directly after generation will probably fail as the parameters
 // need to be manually added.
 
-import { test } from "tap";
+import { test } from "node:test";import { strict as assert } from "node:assert/strict";
 import Fastify from "fastify";
 import fastifyPlugin from "../${data.plugin}";
 import service from "../${data.serviceFile}";
@@ -24,7 +24,7 @@ const opts = {
 // summary:	${route.schema.summary}
 ${comments(route, 0)}
 test("testing ${route.operationId}", (t) => {
-	t.plan(2);
+
 	const fastify = Fastify();
 	fastify.register(fastifyPlugin, opts);
 
@@ -40,8 +40,8 @@ test("testing ${route.operationId}", (t) => {
 			}
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.statusCode, 200);
+	assert.ifError(err);
+		assert.equal(res.statusCode, 200);
 		},
 	);
 });`,

--- a/test/test-cli.js
+++ b/test/test-cli.js
@@ -1,5 +1,6 @@
 import { fileURLToPath, URL } from "url";
-import { test } from "tap";
+import { test } from "node:test";
+import { strict as assert } from "node:assert/strict";
 import { execSync } from "child_process";
 import { createRequire } from "module";
 import { templateTypes } from "../lib/templates/templateTypes.js";
@@ -20,33 +21,30 @@ for (const type of templateTypes) {
 	const project = `generated-${type}-project`;
 	const testChecksums = await importJSON(checksumFile);
 	await test(`cli ${type} does not error`, (t) => {
-		t.plan(1);
 		const checksums = JSON.parse(
 			execSync(`node ${cli} -c -p ${project} -t ${type} ${specPath}`),
 		);
-		t.same(checksums, testChecksums, "checksums match");
+		assert.deepEqual(checksums, testChecksums, "checksums match");
 	});
 
 	await test("cli with local plugin", (t) => {
-		t.plan(1);
 		const result = execSync(
 			`node ${cli} -c -l -p ${project} -t ${type} ${specPath}`,
 		);
-		t.ok(result);
+		assert.ok(result);
 	});
 }
 
 test("cli fails on no spec", (t) => {
-	t.plan(1);
-	t.throws(() => execSync(`node ${cli}`));
+	assert.throws(() => execSync(`node ${cli}`));
 });
 
 test("cli fails on invalid projectType", (t) => {
-	t.plan(1);
-	t.throws(() => execSync(`node ${cli} -c -l ${spec}.json -t nonExistent`));
+	assert.throws(() =>
+		execSync(`node ${cli} -c -l ${spec}.json -t nonExistent`),
+	);
 });
 
 test("cli fails on invalid spec", (t) => {
-	t.plan(1);
-	t.throws(() => execSync(`node ${cli} -c nonExistingSpec.json`));
+	assert.throws(() => execSync(`node ${cli} -c nonExistingSpec.json`));
 });

--- a/test/test-custom-route-options.js
+++ b/test/test-custom-route-options.js
@@ -1,4 +1,5 @@
-import { test } from "tap";
+import { test } from "node:test";
+import { strict as assert } from "node:assert/strict";
 import Fastify from "fastify";
 import fastifyOpenapiGlue from "../index.js";
 import { createRequire } from "module";
@@ -8,7 +9,6 @@ const importJSON = createRequire(import.meta.url);
 const testSpec = await importJSON("./test-openapi.v3.json");
 
 test("return route params from operationResolver", (t) => {
-	t.plan(2);
 	const fastify = Fastify();
 	fastify.register(fastifyOpenapiGlue, {
 		specification: testSpec,
@@ -31,14 +31,13 @@ test("return route params from operationResolver", (t) => {
 			url: "/queryParamObject?int1=1&int2=2",
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.statusCode, 304);
+			assert.ifError(err);
+			assert.equal(res.statusCode, 304);
 		},
 	);
 });
 
 test("operationResolver route params overwrite default params", (t) => {
-	t.plan(3);
 	const fastify = Fastify();
 	fastify.register(fastifyOpenapiGlue, {
 		specification: testSpec,
@@ -58,15 +57,14 @@ test("operationResolver route params overwrite default params", (t) => {
 			url: "/queryParamObject?int1=1&int2=2",
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.statusCode, 200);
-			t.has(JSON.parse(res.body), { foo: "bar" });
+			assert.ifError(err);
+			assert.equal(res.statusCode, 200);
+			assert.equal(JSON.parse(res.body)?.foo, "bar");
 		},
 	);
 });
 
 test("throw an error if handler is not specified", (t) => {
-	t.plan(3);
 	const fastify = Fastify();
 	fastify.register(fastifyOpenapiGlue, {
 		specification: testSpec,
@@ -79,13 +77,15 @@ test("throw an error if handler is not specified", (t) => {
 			url: "/queryParamObject?int1=1&int2=2",
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.statusCode, 500);
-			t.has(JSON.parse(res.body), {
-				statusCode: 500,
-				error: "Internal Server Error",
-				message: "Operation getQueryParamObject not implemented",
-			});
+			assert.ifError(err);
+			assert.equal(res.statusCode, 500);
+			const parsedBody = JSON.parse(res.body);
+			assert.equal(parsedBody?.statusCode, 500);
+			assert.equal(parsedBody?.error, "Internal Server Error");
+			assert.equal(
+				parsedBody?.message,
+				"Operation getQueryParamObject not implemented",
+			);
 		},
 	);
 });

--- a/test/test-debuglogging.js
+++ b/test/test-debuglogging.js
@@ -1,5 +1,6 @@
 // just test the basics to aid debugging
-import { test } from "tap";
+import { test } from "node:test";
+import { strict as assert } from "node:assert/strict";
 import Fastify from "fastify";
 import fastifyOpenapiGlue from "../index.js";
 import { createRequire } from "module";
@@ -41,7 +42,6 @@ test("Service registration is logged at level 'debug'", async (t) => {
 		specification: testSpec,
 		service,
 	};
-	t.plan(2);
 	const fastify = Fastify({
 		logger: {
 			level: "debug",
@@ -53,7 +53,7 @@ test("Service registration is logged at level 'debug'", async (t) => {
 		method: "get",
 		url: "/noParam",
 	});
-	t.equal(res.statusCode, 200, "result is ok");
+	assert.equal(res.statusCode, 200, "result is ok");
 	const operations = new Set();
 	for await (const data of catcher.data) {
 		const match = data.match(/"msg":"service has '(\w+)'"/);
@@ -61,7 +61,7 @@ test("Service registration is logged at level 'debug'", async (t) => {
 			operations.add(match[1]);
 		}
 	}
-	t.equal(
+	assert.equal(
 		missingMethods(service, operations),
 		false,
 		"all operations are present in the debug log",
@@ -79,7 +79,6 @@ test("Error from invalid securityHandler is logged at level 'debug' ", async (t)
 			failing: securityHandlers.failingAuthCheck,
 		},
 	};
-	t.plan(2);
 	const fastify = Fastify({
 		logger: {
 			level: "debug",
@@ -91,7 +90,7 @@ test("Error from invalid securityHandler is logged at level 'debug' ", async (t)
 		method: "GET",
 		url: "/operationSecurity",
 	});
-	t.equal(res.statusCode, 200, "request succeeded");
+	assert.equal(res.statusCode, 200, "request succeeded");
 	const handlers = new Set();
 	for await (const data of catcher.data) {
 		const match = data.match(
@@ -101,7 +100,7 @@ test("Error from invalid securityHandler is logged at level 'debug' ", async (t)
 			handlers.add(match[0]);
 		}
 	}
-	t.equal(
+	assert.equal(
 		handlers.has(
 			"Security handler 'api_key' failed: 'API key was invalid or not found'",
 		),

--- a/test/test-fastify-cli.js
+++ b/test/test-fastify-cli.js
@@ -1,26 +1,25 @@
 // test fastify-cli as used by the npm start script
 import { fileURLToPath, URL } from "url";
 import { build } from "fastify-cli/helper.js";
-import { test } from "tap";
+import { test, after } from "node:test";
+import { strict as assert } from "node:assert/strict";
 
 function localFile(fileName) {
 	return fileURLToPath(new URL(fileName, import.meta.url));
 }
 
 test("test fastify-cli with petstore example", async (t) => {
-	t.plan(2);
-
 	const fastifyCli = await build([
 		"--options",
 		localFile("../examples/petstore/index.js"),
 	]);
-	t.teardown(() => fastifyCli.close());
+	after(() => fastifyCli.close());
 	const res = await fastifyCli.inject({
 		method: "GET",
 		url: "v2/pet/24",
 	});
-	t.equal(res.statusCode, 200);
-	t.equal(
+	assert.equal(res.statusCode, 200);
+	assert.equal(
 		res.body,
 		'{"id":24,"name":"Kitty the cat","photoUrls":["https://en.wikipedia.org/wiki/Cat#/media/File:Kittyply_edit1.jpg"],"status":"available"}',
 	);

--- a/test/test-fastify-recursive.js
+++ b/test/test-fastify-recursive.js
@@ -1,4 +1,5 @@
-import { test } from "tap";
+import { test } from "node:test";
+import { strict as assert } from "node:assert/strict";
 import Fastify from "fastify";
 
 const opts = {
@@ -21,12 +22,11 @@ const opts = {
 };
 
 test("fastify validation works", (t) => {
-	t.plan(5);
 	const fastify = Fastify();
 
 	async function routes(fastify) {
 		fastify.post("/", opts, async (request) => {
-			t.same(
+			assert.deepEqual(
 				request.body,
 				{ str1: "test data", obj1: { str1: "test data" } },
 				"expected value",
@@ -47,8 +47,8 @@ test("fastify validation works", (t) => {
 			},
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.statusCode, 200, "expected HTTP code");
+			assert.ifError(err);
+			assert.equal(res.statusCode, 200, "expected HTTP code");
 		},
 	);
 	fastify.inject(
@@ -57,8 +57,8 @@ test("fastify validation works", (t) => {
 			url: "/blah",
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.statusCode, 404, "expected HTTP code");
+			assert.ifError(err);
+			assert.equal(res.statusCode, 404, "expected HTTP code");
 		},
 	);
 });

--- a/test/test-fastify.js
+++ b/test/test-fastify.js
@@ -1,5 +1,6 @@
 // just test the basics to aid debugging
-import { test } from "tap";
+import { test } from "node:test";
+import { strict as assert } from "node:assert/strict";
 import Fastify from "fastify";
 
 const opts = {
@@ -15,7 +16,6 @@ const opts = {
 };
 
 test("basic fastify works", (t) => {
-	t.plan(2);
 	const fastify = Fastify();
 
 	async function routes(fastify) {
@@ -30,14 +30,13 @@ test("basic fastify works", (t) => {
 			url: "/",
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.statusCode, 200);
+			assert.ifError(err);
+			assert.equal(res.statusCode, 200);
 		},
 	);
 });
 
 test("fastify validation works", (t) => {
-	t.plan(5);
 	const fastify = Fastify();
 
 	async function routes(fastify) {
@@ -52,9 +51,9 @@ test("fastify validation works", (t) => {
 			url: "/?hello=world",
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.body, '{"hello":"world"}', "expected value");
-			t.equal(res.statusCode, 200, "expected HTTP code");
+			assert.ifError(err);
+			assert.equal(res.body, '{"hello":"world"}', "expected value");
+			assert.equal(res.statusCode, 200, "expected HTTP code");
 		},
 	);
 	fastify.inject(
@@ -63,8 +62,8 @@ test("fastify validation works", (t) => {
 			url: "/?ello=world",
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.statusCode, 400, "expected HTTP code");
+			assert.ifError(err);
+			assert.equal(res.statusCode, 400, "expected HTTP code");
 		},
 	);
 });

--- a/test/test-generate-project.js
+++ b/test/test-generate-project.js
@@ -1,4 +1,5 @@
-import { test } from "tap";
+import { test } from "node:test";
+import { strict as assert } from "node:assert/strict";
 import { Generator } from "../lib/generator.js";
 import { createRequire } from "module";
 import { templateTypes } from "../lib/templates/templateTypes.js";
@@ -20,51 +21,44 @@ const localGenerator = new Generator(checksumOnly, localPlugin);
 const generator = new Generator(checksumOnly, noLocalPlugin);
 
 test("generator generates V3.0.0 project without error", async (t) => {
-	t.plan(1);
-
 	try {
 		await generator.parse(specPath3);
 		await generator.generateProject(dir, projectName);
-		t.pass("no error occurred");
+		assert.ok(true, "no error occurred");
 	} catch (e) {
-		t.fail(e.message);
+		assert.fail(e.message);
 	}
 });
 
 test("generator generates V3.0.1 project without error", async (t) => {
 	spec301["openapi"] = "3.0.1";
-	t.plan(1);
 
 	try {
 		await generator.parse(spec301);
 		await generator.generateProject(dir, projectName);
-		t.pass("no error occurred");
+		assert.ok(true, "no error occurred");
 	} catch (e) {
-		t.fail(e.message);
+		assert.fail(e.message);
 	}
 });
 
 test("generator generates project with local plugin without error", async (t) => {
-	t.plan(1);
-
 	try {
 		await localGenerator.parse(specPath);
 		await localGenerator.generateProject(dir, projectName);
-		t.pass("no error occurred");
+		assert.ok(true, "no error occurred");
 	} catch (e) {
-		t.fail(e.message);
+		assert.fail(e.message);
 	}
 });
 
 test("generator throws error on non-existent basedir", async (t) => {
-	t.plan(1);
-
 	try {
 		await generator.parse(specPath);
 		await generator.generateProject(nonExistentDir, projectName);
-		t.fail("no error occurred");
+		assert.fail("no error occurred");
 	} catch (e) {
-		t.equal(e.code, "ENOENT", "got expected error");
+		assert.equal(e.code, "ENOENT", "got expected error");
 	}
 });
 
@@ -74,14 +68,12 @@ for (const type of templateTypes) {
 	const project = `generated-${type}-project`;
 	const generator = new Generator(checksumOnly, localPlugin);
 	await test(`generator generates ${type} project without error`, async (t) => {
-		t.plan(1);
-
 		try {
 			await generator.parse(specPath);
 			await generator.generateProject(dir, project, type);
-			t.pass("no error occurred");
+			assert.ok(true, "no error occurred");
 		} catch (e) {
-			t.fail(e.message);
+			assert.fail(e.message);
 		}
 	});
 }

--- a/test/test-generator.js
+++ b/test/test-generator.js
@@ -1,4 +1,5 @@
-import { test } from "tap";
+import { test } from "node:test";
+import { strict as assert } from "node:assert/strict";
 import { Generator } from "../lib/generator.js";
 import { createRequire } from "module";
 import { templateTypes } from "../lib/templates/templateTypes.js";
@@ -19,14 +20,12 @@ for (const type of templateTypes) {
 		const project = `generated-${type}-project`;
 		const generator = new Generator(checksumOnly, localPlugin);
 		await test(`generator generates ${type} project data for ${spec}`, async (t) => {
-			t.plan(1);
-
 			try {
 				await generator.parse(specFile);
 				const checksums = await generator.generateProject(dir, project, type);
-				t.same(checksums, testChecksums, "checksums match");
+				assert.deepEqual(checksums, testChecksums, "checksums match");
 			} catch (e) {
-				t.fail(e.message);
+				assert.fail(e.message);
 			}
 		});
 	}

--- a/test/test-import-plugin.cjs
+++ b/test/test-import-plugin.cjs
@@ -1,7 +1,6 @@
 const { test } = require("tap");
 
 test("import in CommonJS works", async (t) => {
-	t.plan(1);
 	const openapiGlue = await import("../index.js");
-	t.equal(openapiGlue.fastifyOpenapiGlue !== undefined, true);
+	assert.equal(openapiGlue.fastifyOpenapiGlue !== undefined, true);
 });

--- a/test/test-import-plugin.js
+++ b/test/test-import-plugin.js
@@ -1,13 +1,12 @@
-import { test } from "tap";
+import { test } from "node:test";
+import { strict as assert } from "node:assert/strict";
 import { fastifyOpenapiGlue } from "../index.js";
 import openapiGlue from "../index.js";
 
 test("named import in ESM works", async (t) => {
-	t.plan(1);
-	t.equal(fastifyOpenapiGlue.fastifyOpenapiGlue !== undefined, true);
+	assert.equal(fastifyOpenapiGlue.fastifyOpenapiGlue !== undefined, true);
 });
 
 test("default import in ESM works", async (t) => {
-	t.plan(1);
-	t.equal(openapiGlue.fastifyOpenapiGlue !== undefined, true);
+	assert.equal(openapiGlue.fastifyOpenapiGlue !== undefined, true);
 });

--- a/test/test-parser-base.js
+++ b/test/test-parser-base.js
@@ -1,11 +1,11 @@
 // just test the basics to aid debugging
-import { test } from "tap";
+import { test } from "node:test";
+import { strict as assert } from "node:assert/strict";
 import { ParserBase } from "../lib/ParserBase.js";
 
 test("generation of operationId works", (t) => {
-	t.plan(1);
 	const pb = new ParserBase();
-	t.equal(
+	assert.equal(
 		pb.makeOperationId("get", "/user/{name}"),
 		"getUserByName",
 		"get /user/{name} becomes getUserByName",

--- a/test/test-petstore-example.js
+++ b/test/test-petstore-example.js
@@ -1,10 +1,10 @@
 // this suite tests the examples shown in README.md
-import { test } from "tap";
+import { test } from "node:test";
+import { strict as assert } from "node:assert/strict";
 import Fastify from "fastify";
 import petstoreExample, { options } from "../examples/petstore/index.js";
 
 test("/v2/pet/24 works", (t) => {
-	t.plan(3);
 	const fastify = Fastify(options);
 	fastify.register(petstoreExample, {});
 	fastify.inject(
@@ -13,9 +13,9 @@ test("/v2/pet/24 works", (t) => {
 			url: "v2/pet/24",
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.statusCode, 200);
-			t.equal(
+			assert.ifError(err);
+			assert.equal(res.statusCode, 200);
+			assert.equal(
 				res.body,
 				'{"id":24,"name":"Kitty the cat","photoUrls":["https://en.wikipedia.org/wiki/Cat#/media/File:Kittyply_edit1.jpg"],"status":"available"}',
 			);
@@ -24,7 +24,6 @@ test("/v2/pet/24 works", (t) => {
 });
 
 test("/v2/pet/myPet returns Fastify validation error", (t) => {
-	t.plan(3);
 	const fastify = Fastify(options);
 	fastify.register(petstoreExample, {});
 	fastify.inject(
@@ -33,19 +32,17 @@ test("/v2/pet/myPet returns Fastify validation error", (t) => {
 			url: "v2/pet/myPet",
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.statusCode, 400);
-			t.has(JSON.parse(res.body), {
-				statusCode: 400,
-				error: "Bad Request",
-				message: "params/petId must be integer",
-			});
+			assert.ifError(err);
+			assert.equal(res.statusCode, 400);
+			const parsedBody = JSON.parse(res.body);
+			assert.equal(parsedBody.statusCode, 400);
+			assert.equal(parsedBody.error, "Bad Request");
+			assert.equal(parsedBody.message, "params/petId must be integer");
 		},
 	);
 });
 
 test("v2/pet/findByStatus?status=available&status=pending returns 'not implemented'", (t) => {
-	t.plan(3);
 	const fastify = Fastify(options);
 	fastify.register(petstoreExample, {});
 	fastify.inject(
@@ -54,19 +51,20 @@ test("v2/pet/findByStatus?status=available&status=pending returns 'not implement
 			url: "v2/pet/findByStatus?status=available&status=pending",
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.statusCode, 500);
-			t.has(JSON.parse(res.body), {
-				statusCode: 500,
-				error: "Internal Server Error",
-				message: "Operation findPetsByStatus not implemented",
-			});
+			assert.ifError(err);
+			assert.equal(res.statusCode, 500);
+			const parsedBody = JSON.parse(res.body);
+			assert.equal(parsedBody.statusCode, 500);
+			assert.equal(parsedBody.error, "Internal Server Error");
+			assert.equal(
+				parsedBody.message,
+				"Operation findPetsByStatus not implemented",
+			);
 		},
 	);
 });
 
 test("v2/pet/0 returns serialization error", (t) => {
-	t.plan(3);
 	const fastify = Fastify(options);
 	fastify.register(petstoreExample, {});
 	fastify.inject(
@@ -75,13 +73,12 @@ test("v2/pet/0 returns serialization error", (t) => {
 			url: "v2/pet/0",
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.statusCode, 500);
-			t.has(JSON.parse(res.body), {
-				statusCode: 500,
-				error: "Internal Server Error",
-				message: '"name" is required!',
-			});
+			assert.ifError(err);
+			assert.equal(res.statusCode, 500);
+			const parsedBody = JSON.parse(res.body);
+			assert.equal(parsedBody.statusCode, 500);
+			assert.equal(parsedBody.error, "Internal Server Error");
+			assert.equal(parsedBody.message, '"name" is required!');
 		},
 	);
 });

--- a/test/test-plugin.v2.js
+++ b/test/test-plugin.v2.js
@@ -1,4 +1,5 @@
-import { test } from "tap";
+import { test } from "node:test";
+import { strict as assert } from "node:assert/strict";
 import Fastify from "fastify";
 import fastifyOpenapiGlue from "../index.js";
 import { createRequire } from "module";
@@ -50,7 +51,6 @@ const petStoreOpts = {
 };
 
 test("path parameters work", (t) => {
-	t.plan(2);
 	const fastify = Fastify();
 	fastify.register(fastifyOpenapiGlue, opts);
 
@@ -60,14 +60,13 @@ test("path parameters work", (t) => {
 			url: "/v2/pathParam/2",
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.statusCode, 200);
+			assert.ifError(err);
+			assert.equal(res.statusCode, 200);
 		},
 	);
 });
 
 test("query parameters work", (t) => {
-	t.plan(2);
 	const fastify = Fastify();
 	fastify.register(fastifyOpenapiGlue, opts);
 
@@ -77,14 +76,13 @@ test("query parameters work", (t) => {
 			url: "/v2/queryParam?int1=1&int2=2",
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.statusCode, 200);
+			assert.ifError(err);
+			assert.equal(res.statusCode, 200);
 		},
 	);
 });
 
 test("header parameters work", (t) => {
-	t.plan(2);
 	const fastify = Fastify();
 	fastify.register(fastifyOpenapiGlue, opts);
 
@@ -97,14 +95,13 @@ test("header parameters work", (t) => {
 			},
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.statusCode, 200);
+			assert.ifError(err);
+			assert.equal(res.statusCode, 200);
 		},
 	);
 });
 
 test("body parameters work", (t) => {
-	t.plan(2);
 	const fastify = Fastify();
 	fastify.register(fastifyOpenapiGlue, opts);
 
@@ -115,14 +112,13 @@ test("body parameters work", (t) => {
 			payload: { str1: "test data" },
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.statusCode, 200);
+			assert.ifError(err);
+			assert.equal(res.statusCode, 200);
 		},
 	);
 });
 
 test("no parameters work", (t) => {
-	t.plan(2);
 	const fastify = Fastify();
 	fastify.register(fastifyOpenapiGlue, opts);
 
@@ -132,14 +128,13 @@ test("no parameters work", (t) => {
 			url: "/v2/noParam",
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.statusCode, 200);
+			assert.ifError(err);
+			assert.equal(res.statusCode, 200);
 		},
 	);
 });
 
 test("missing operation from service returns error 500", (t) => {
-	t.plan(2);
 	const fastify = Fastify();
 	fastify.register(fastifyOpenapiGlue, opts);
 
@@ -149,14 +144,13 @@ test("missing operation from service returns error 500", (t) => {
 			url: "/v2/noOperationId/1",
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.statusCode, 500);
+			assert.ifError(err);
+			assert.equal(res.statusCode, 500);
 		},
 	);
 });
 
 test("response schema works with valid response", (t) => {
-	t.plan(2);
 	const fastify = Fastify();
 	fastify.register(fastifyOpenapiGlue, opts);
 
@@ -166,14 +160,13 @@ test("response schema works with valid response", (t) => {
 			url: "/v2/responses?replyType=valid",
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.statusCode, 200);
+			assert.ifError(err);
+			assert.equal(res.statusCode, 200);
 		},
 	);
 });
 
 test("response schema works with invalid response", (t) => {
-	t.plan(2);
 	const fastify = Fastify();
 	fastify.register(fastifyOpenapiGlue, opts);
 
@@ -183,14 +176,13 @@ test("response schema works with invalid response", (t) => {
 			url: "/v2/responses?replyType=invalid",
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.statusCode, 500);
+			assert.ifError(err);
+			assert.equal(res.statusCode, 500);
 		},
 	);
 });
 
 test("yaml spec works", (t) => {
-	t.plan(2);
 	const fastify = Fastify();
 	fastify.register(fastifyOpenapiGlue, yamlOpts);
 
@@ -200,84 +192,79 @@ test("yaml spec works", (t) => {
 			url: "/v2/pathParam/2",
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.statusCode, 200);
+			assert.ifError(err);
+			assert.equal(res.statusCode, 200);
 		},
 	);
 });
 
 test("invalid openapi v2 specification throws error ", (t) => {
-	t.plan(1);
 	const fastify = Fastify();
 	fastify.register(fastifyOpenapiGlue, invalidSwaggerOpts);
 	fastify.ready((err) => {
 		if (err) {
-			t.equal(
+			assert.equal(
 				err.message,
 				"'specification' parameter must contain a valid version 2.0 or 3.0.x or 3.1.x specification",
 				"got expected error",
 			);
 		} else {
-			t.fail("missed expected error");
+			assert.fail("missed expected error");
 		}
 	});
 });
 
 test("missing service definition throws error ", (t) => {
-	t.plan(1);
 	const fastify = Fastify();
 	fastify.register(fastifyOpenapiGlue, invalidServiceOpts);
 	fastify.ready((err) => {
 		if (err) {
-			t.equal(
+			assert.equal(
 				err.message,
 				"'service' parameter must refer to an object",
 				"got expected error",
 			);
 		} else {
-			t.fail("missed expected error");
+			assert.fail("missed expected error");
 		}
 	});
 });
 
 test("invalid service definition throws error ", (t) => {
-	t.plan(1);
 	const fastify = Fastify();
 	fastify.register(fastifyOpenapiGlue, missingServiceOpts);
 	fastify.ready((err) => {
 		if (err) {
-			t.match(
+			assert.equal(
 				err.message,
 				"'service' parameter must refer to an object",
 				"got expected error",
 			);
 		} else {
-			t.fail("missed expected error");
+			assert.fail("missed expected error");
 		}
 	});
 });
 
 test("full pet store V2 definition does not throw error ", (t) => {
-	t.plan(1);
 	const fastify = Fastify(noStrict);
 	fastify.register(fastifyOpenapiGlue, petStoreOpts);
 	fastify.ready((err) => {
 		if (err) {
-			t.fail("got unexpected error");
+			assert.fail("got unexpected error");
 		} else {
-			t.pass("no unexpected error");
+			assert.ok(true, "no unexpected error");
 		}
 	});
 });
 
 test("x- props are copied", (t) => {
-	t.plan(3);
 	const fastify = Fastify();
 	fastify.addHook("preHandler", async (request, reply) => {
 		if (request.routeSchema["x-tap-ok"]) {
-			t.pass("found x- prop");
+			assert.ok(true, "found x- prop");
 		} else {
-			t.fail("missing x- prop");
+			assert.fail("missing x- prop");
 		}
 	});
 	fastify.register(fastifyOpenapiGlue, opts);
@@ -288,20 +275,19 @@ test("x- props are copied", (t) => {
 			url: "/v2/queryParam?int1=1&int2=2",
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.statusCode, 200);
+			assert.ifError(err);
+			assert.equal(res.statusCode, 200);
 		},
 	);
 });
 
 test("x-fastify-config is applied", (t) => {
-	t.plan(1);
 	const fastify = Fastify();
 	fastify.register(fastifyOpenapiGlue, {
 		...opts,
 		service: {
 			operationWithFastifyConfigExtension: (req, reply) => {
-				t.equal(req.routeConfig.rawBody, true, "config.rawBody is true");
+				assert.equal(req.routeConfig.rawBody, true, "config.rawBody is true");
 				return reply;
 			},
 		},
@@ -313,7 +299,7 @@ test("x-fastify-config is applied", (t) => {
 			url: "/v2/operationWithFastifyConfigExtension",
 		},
 		() => {
-			t.pass();
+			assert.ok(true);
 		},
 	);
 });

--- a/test/test-plugin.v3.js
+++ b/test/test-plugin.v3.js
@@ -1,4 +1,5 @@
-import { test } from "tap";
+import { test } from "node:test";
+import { strict as assert } from "node:assert/strict";
 import Fastify from "fastify";
 import fastifyOpenapiGlue from "../index.js";
 import { createRequire } from "module";
@@ -91,7 +92,6 @@ const withOperationResolverUsingMethodPath = {
 };
 
 test("path parameters work", (t) => {
-	t.plan(2);
 	const fastify = Fastify();
 	fastify.register(fastifyOpenapiGlue, opts);
 
@@ -101,14 +101,13 @@ test("path parameters work", (t) => {
 			url: "/pathParam/2",
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.statusCode, 200);
+			assert.ifError(err);
+			assert.equal(res.statusCode, 200);
 		},
 	);
 });
 
 test("query parameters work", (t) => {
-	t.plan(2);
 	const fastify = Fastify();
 	fastify.register(fastifyOpenapiGlue, opts);
 
@@ -118,14 +117,13 @@ test("query parameters work", (t) => {
 			url: "/queryParam?int1=1&int2=2",
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.statusCode, 200);
+			assert.ifError(err);
+			assert.equal(res.statusCode, 200);
 		},
 	);
 });
 
 test("query parameters with object schema work", (t) => {
-	t.plan(2);
 	const fastify = Fastify();
 	fastify.register(fastifyOpenapiGlue, opts);
 
@@ -135,14 +133,13 @@ test("query parameters with object schema work", (t) => {
 			url: "/queryParamObject?int1=1&int2=2",
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.statusCode, 200);
+			assert.ifError(err);
+			assert.equal(res.statusCode, 200);
 		},
 	);
 });
 
 test("query parameters with array schema work", (t) => {
-	t.plan(2);
 	const fastify = Fastify();
 	fastify.register(fastifyOpenapiGlue, opts);
 
@@ -152,14 +149,13 @@ test("query parameters with array schema work", (t) => {
 			url: "/queryParamArray?arr=1&arr=2",
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.statusCode, 200);
+			assert.ifError(err);
+			assert.equal(res.statusCode, 200);
 		},
 	);
 });
 
 test("header parameters work", (t) => {
-	t.plan(2);
 	const fastify = Fastify();
 	fastify.register(fastifyOpenapiGlue, opts);
 
@@ -172,14 +168,13 @@ test("header parameters work", (t) => {
 			},
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.statusCode, 200);
+			assert.ifError(err);
+			assert.equal(res.statusCode, 200);
 		},
 	);
 });
 
 test("missing header parameters returns error 500", (t) => {
-	t.plan(2);
 	const fastify = Fastify();
 	fastify.register(fastifyOpenapiGlue, opts);
 
@@ -189,14 +184,13 @@ test("missing header parameters returns error 500", (t) => {
 			url: "/headerParam",
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.statusCode, 500);
+			assert.ifError(err);
+			assert.equal(res.statusCode, 500);
 		},
 	);
 });
 
 test("missing authorization header returns error 500", (t) => {
-	t.plan(2);
 	const fastify = Fastify();
 	fastify.register(fastifyOpenapiGlue, opts);
 
@@ -206,14 +200,13 @@ test("missing authorization header returns error 500", (t) => {
 			url: "/authHeaderParam",
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.statusCode, 500);
+			assert.ifError(err);
+			assert.equal(res.statusCode, 500);
 		},
 	);
 });
 
 test("body parameters work", (t) => {
-	t.plan(2);
 	const fastify = Fastify();
 	fastify.register(fastifyOpenapiGlue, opts);
 
@@ -227,14 +220,13 @@ test("body parameters work", (t) => {
 			},
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.statusCode, 200);
+			assert.ifError(err);
+			assert.equal(res.statusCode, 200);
 		},
 	);
 });
 
 test("no parameters work", (t) => {
-	t.plan(2);
 	const fastify = Fastify();
 	fastify.register(fastifyOpenapiGlue, opts);
 
@@ -244,14 +236,13 @@ test("no parameters work", (t) => {
 			url: "/noParam",
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.statusCode, 200);
+			assert.ifError(err);
+			assert.equal(res.statusCode, 200);
 		},
 	);
 });
 
 test("prefix in opts works", (t) => {
-	t.plan(2);
 	const fastify = Fastify();
 	fastify.register(fastifyOpenapiGlue, prefixOpts);
 
@@ -261,14 +252,13 @@ test("prefix in opts works", (t) => {
 			url: "/prefix/noParam",
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.statusCode, 200);
+			assert.ifError(err);
+			assert.equal(res.statusCode, 200);
 		},
 	);
 });
 
 test("missing operation from service returns error 500", (t) => {
-	t.plan(2);
 	const fastify = Fastify();
 	fastify.register(fastifyOpenapiGlue, opts);
 
@@ -278,14 +268,13 @@ test("missing operation from service returns error 500", (t) => {
 			url: "/noOperationId/1",
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.statusCode, 500);
+			assert.ifError(err);
+			assert.equal(res.statusCode, 500);
 		},
 	);
 });
 
 test("response schema works with valid response", (t) => {
-	t.plan(2);
 	const fastify = Fastify();
 	fastify.register(fastifyOpenapiGlue, opts);
 
@@ -295,14 +284,13 @@ test("response schema works with valid response", (t) => {
 			url: "/responses?replyType=valid",
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.statusCode, 200);
+			assert.ifError(err);
+			assert.equal(res.statusCode, 200);
 		},
 	);
 });
 
 test("response schema works with invalid response", (t) => {
-	t.plan(2);
 	const fastify = Fastify();
 	fastify.register(fastifyOpenapiGlue, opts);
 
@@ -312,14 +300,13 @@ test("response schema works with invalid response", (t) => {
 			url: "/responses?replyType=invalid",
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.statusCode, 500);
+			assert.ifError(err);
+			assert.equal(res.statusCode, 500);
 		},
 	);
 });
 
 test("yaml spec works", (t) => {
-	t.plan(2);
 	const fastify = Fastify(noStrict);
 	fastify.register(fastifyOpenapiGlue, yamlOpts);
 
@@ -329,14 +316,13 @@ test("yaml spec works", (t) => {
 			url: "/pathParam/2",
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.statusCode, 200);
+			assert.ifError(err);
+			assert.equal(res.statusCode, 200);
 		},
 	);
 });
 
 test("generic path parameters work", (t) => {
-	t.plan(2);
 	const fastify = Fastify();
 	fastify.register(fastifyOpenapiGlue, genericPathItemsOpts);
 
@@ -346,14 +332,13 @@ test("generic path parameters work", (t) => {
 			url: "/pathParam/2",
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.statusCode, 200);
+			assert.ifError(err);
+			assert.equal(res.statusCode, 200);
 		},
 	);
 });
 
 test("generic path parameters override works", (t) => {
-	t.plan(2);
 	const fastify = Fastify();
 	fastify.register(fastifyOpenapiGlue, genericPathItemsOpts);
 
@@ -363,48 +348,45 @@ test("generic path parameters override works", (t) => {
 			url: "/noParam",
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.statusCode, 200);
+			assert.ifError(err);
+			assert.equal(res.statusCode, 200);
 		},
 	);
 });
 
 test("invalid openapi v3 specification throws error ", (t) => {
-	t.plan(1);
 	const fastify = Fastify();
 	fastify.register(fastifyOpenapiGlue, invalidSwaggerOpts);
 	fastify.ready((err) => {
 		if (err) {
-			t.equal(
+			assert.equal(
 				err.message,
 				"'specification' parameter must contain a valid version 2.0 or 3.0.x or 3.1.x specification",
 				"got expected error",
 			);
 		} else {
-			t.fail("missed expected error");
+			assert.fail("missed expected error");
 		}
 	});
 });
 
 test("missing service definition throws error ", (t) => {
-	t.plan(1);
 	const fastify = Fastify();
 	fastify.register(fastifyOpenapiGlue, invalidServiceOpts);
 	fastify.ready((err) => {
 		if (err) {
-			t.equal(
+			assert.equal(
 				err.message,
 				"'service' parameter must refer to an object",
 				"got expected error",
 			);
 		} else {
-			t.fail("missed expected error");
+			assert.fail("missed expected error");
 		}
 	});
 });
 
 test("full pet store V3 definition does not throw error ", (t) => {
-	t.plan(1);
 	const fastify = Fastify(noStrict);
 	// dummy parser to fix coverage testing
 	fastify.addContentTypeParser(
@@ -417,9 +399,9 @@ test("full pet store V3 definition does not throw error ", (t) => {
 	fastify.register(fastifyOpenapiGlue, petStoreOpts);
 	fastify.ready((err) => {
 		if (err) {
-			t.fail("got unexpected error");
+			assert.fail("got unexpected error");
 		} else {
-			t.pass("no unexpected error");
+			assert.ok(true, "no unexpected error");
 		}
 	});
 });
@@ -432,14 +414,13 @@ test("V3.0.1 definition does not throw error", (t) => {
 		service,
 	};
 
-	t.plan(1);
 	const fastify = Fastify(noStrict);
 	fastify.register(fastifyOpenapiGlue, opts301);
 	fastify.ready((err) => {
 		if (err) {
-			t.fail("got unexpected error");
+			assert.fail("got unexpected error");
 		} else {
-			t.pass("no unexpected error");
+			assert.ok(true, "no unexpected error");
 		}
 	});
 });
@@ -452,14 +433,13 @@ test("V3.0.2 definition does not throw error", (t) => {
 		service,
 	};
 
-	t.plan(1);
 	const fastify = Fastify(noStrict);
 	fastify.register(fastifyOpenapiGlue, opts302);
 	fastify.ready((err) => {
 		if (err) {
-			t.fail("got unexpected error");
+			assert.fail("got unexpected error");
 		} else {
-			t.pass("no unexpected error");
+			assert.ok(true, "no unexpected error");
 		}
 	});
 });
@@ -472,26 +452,24 @@ test("V3.0.3 definition does not throw error", (t) => {
 		service,
 	};
 
-	t.plan(1);
 	const fastify = Fastify(noStrict);
 	fastify.register(fastifyOpenapiGlue, opts303);
 	fastify.ready((err) => {
 		if (err) {
-			t.fail("got unexpected error");
+			assert.fail("got unexpected error");
 		} else {
-			t.pass("no unexpected error");
+			assert.ok(true, "no unexpected error");
 		}
 	});
 });
 
 test("x- props are copied", (t) => {
-	t.plan(3);
 	const fastify = Fastify();
 	fastify.addHook("preHandler", async (request, reply) => {
 		if (request.routeSchema["x-tap-ok"]) {
-			t.pass("found x- prop");
+			assert.ok(true, "found x- prop");
 		} else {
-			t.fail("missing x- prop");
+			assert.fail("missing x- prop");
 		}
 	});
 	fastify.register(fastifyOpenapiGlue, opts);
@@ -502,20 +480,19 @@ test("x- props are copied", (t) => {
 			url: "/queryParam?int1=1&int2=2",
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.statusCode, 200);
+			assert.ifError(err);
+			assert.equal(res.statusCode, 200);
 		},
 	);
 });
 
 test("x-fastify-config is applied", (t) => {
-	t.plan(1);
 	const fastify = Fastify();
 	fastify.register(fastifyOpenapiGlue, {
 		...opts,
 		service: {
 			operationWithFastifyConfigExtension: (req, reply) => {
-				t.equal(req.routeConfig.rawBody, true, "config.rawBody is true");
+				assert.equal(req.routeConfig.rawBody, true, "config.rawBody is true");
 				return reply;
 			},
 		},
@@ -527,47 +504,44 @@ test("x-fastify-config is applied", (t) => {
 			url: "/operationWithFastifyConfigExtension",
 		},
 		() => {
-			t.pass();
+			assert.ok(true);
 		},
 	);
 });
 
 test("service and operationResolver together throw error", (t) => {
-	t.plan(1);
 	const fastify = Fastify();
 	fastify.register(fastifyOpenapiGlue, serviceAndOperationResolver);
 	fastify.ready((err) => {
 		if (err) {
-			t.equal(
+			assert.equal(
 				err.message,
 				"'service' and 'operationResolver' are mutually exclusive",
 				"got expected error",
 			);
 		} else {
-			t.fail("missed expected error");
+			assert.fail("missed expected error");
 		}
 	});
 });
 
 test("no service and no operationResolver throw error", (t) => {
-	t.plan(1);
 	const fastify = Fastify();
 	fastify.register(fastifyOpenapiGlue, noServiceNoResolver);
 	fastify.ready((err) => {
 		if (err) {
-			t.equal(
+			assert.equal(
 				err.message,
 				"either 'service' or 'operationResolver' are required",
 				"got expected error",
 			);
 		} else {
-			t.fail("missed expected error");
+			assert.fail("missed expected error");
 		}
 	});
 });
 
 test("operation resolver works", (t) => {
-	t.plan(2);
 	const fastify = Fastify();
 	fastify.register(fastifyOpenapiGlue, withOperationResolver);
 
@@ -577,14 +551,13 @@ test("operation resolver works", (t) => {
 			url: "/noParam",
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.body, "ok");
+			assert.ifError(err);
+			assert.equal(res.body, "ok");
 		},
 	);
 });
 
 test("operation resolver with method and url works", (t) => {
-	t.plan(2);
 	const fastify = Fastify();
 	fastify.register(fastifyOpenapiGlue, withOperationResolverUsingMethodPath);
 
@@ -594,8 +567,8 @@ test("operation resolver with method and url works", (t) => {
 			url: "/noParam",
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.body, "ok");
+			assert.ifError(err);
+			assert.equal(res.body, "ok");
 		},
 	);
 });

--- a/test/test-recursive.v3.js
+++ b/test/test-recursive.v3.js
@@ -1,4 +1,5 @@
-import { test } from "tap";
+import { test } from "node:test";
+import { strict as assert } from "node:assert/strict";
 import Fastify from "fastify";
 import fastifyOpenapiGlue from "../index.js";
 import { createRequire } from "module";
@@ -23,14 +24,13 @@ test("route registration succeeds with recursion", (t) => {
 		service,
 	};
 
-	t.plan(1);
 	const fastify = Fastify(noStrict);
 	fastify.register(fastifyOpenapiGlue, opts);
 	fastify.ready((err) => {
 		if (err) {
-			t.fail("got unexpected error");
+			assert.fail("got unexpected error");
 		} else {
-			t.pass("no unexpected error");
+			assert.ok(true, "no unexpected error");
 		}
 	});
 });

--- a/test/test-securityHandlers.v2.js
+++ b/test/test-securityHandlers.v2.js
@@ -1,4 +1,5 @@
-import { test } from "tap";
+import { test } from "node:test";
+import { strict as assert } from "node:assert/strict";
 import Fastify from "fastify";
 import fastifyOpenapiGlue from "../index.js";
 import { createRequire } from "module";
@@ -25,14 +26,13 @@ test("security handler registration succeeds", (t) => {
 		securityHandlers,
 	};
 
-	t.plan(1);
 	const fastify = Fastify(noStrict);
 	fastify.register(fastifyOpenapiGlue, opts);
 	fastify.ready((err) => {
 		if (err) {
-			t.fail("got unexpected error");
+			assert.fail("got unexpected error");
 		} else {
-			t.pass("no unexpected error");
+			assert.ok(true, "no unexpected error");
 		}
 	});
 });
@@ -46,10 +46,9 @@ test("security registration succeeds, but preHandler throws error", (t) => {
 		},
 	};
 
-	t.plan(4);
 	const fastify = Fastify();
 	fastify.setErrorHandler((err, req, reply) => {
-		t.equal(err.errors.length, 3);
+		assert.equal(err.errors.length, 3);
 		reply.code(err.statusCode).send(err);
 	});
 	fastify.register(fastifyOpenapiGlue, opts);
@@ -59,9 +58,9 @@ test("security registration succeeds, but preHandler throws error", (t) => {
 			url: "/v2/operationSecurity",
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.statusCode, 401);
-			t.equal(res.statusMessage, "Unauthorized");
+			assert.ifError(err);
+			assert.equal(res.statusCode, 401);
+			assert.equal(res.statusMessage, "Unauthorized");
 		},
 	);
 });
@@ -76,7 +75,6 @@ test("security preHandler passes with short-circuit", (t) => {
 		},
 	};
 
-	t.plan(3);
 	const fastify = Fastify();
 	fastify.register(fastifyOpenapiGlue, opts);
 	fastify.inject(
@@ -85,9 +83,9 @@ test("security preHandler passes with short-circuit", (t) => {
 			url: "/v2/operationSecurity",
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.statusCode, 200);
-			t.equal(res.statusMessage, "OK");
+			assert.ifError(err);
+			assert.equal(res.statusCode, 200);
+			assert.equal(res.statusMessage, "OK");
 		},
 	);
 });
@@ -102,10 +100,9 @@ test("security preHandler handles multiple failures", (t) => {
 		},
 	};
 
-	t.plan(4);
 	const fastify = Fastify();
 	fastify.setErrorHandler((err, req, reply) => {
-		t.equal(err.errors.length, 3);
+		assert.equal(err.errors.length, 3);
 		reply.code(err.statusCode).send(err);
 	});
 	fastify.register(fastifyOpenapiGlue, opts);
@@ -115,16 +112,14 @@ test("security preHandler handles multiple failures", (t) => {
 			url: "/v2/operationSecurity",
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.statusCode, 401);
-			t.equal(res.statusMessage, "Unauthorized");
+			assert.ifError(err);
+			assert.equal(res.statusCode, 401);
+			assert.equal(res.statusMessage, "Unauthorized");
 		},
 	);
 });
 
 test("initalization of securityHandlers succeeds", (t) => {
-	t.plan(2);
-
 	const opts = {
 		specification: testSpec,
 		service,
@@ -133,7 +128,7 @@ test("initalization of securityHandlers succeeds", (t) => {
 				const securitySchemeFromSpec = JSON.stringify(
 					testSpec.securityDefinitions,
 				);
-				t.equal(JSON.stringify(securitySchemes), securitySchemeFromSpec);
+				assert.equal(JSON.stringify(securitySchemes), securitySchemeFromSpec);
 			},
 		},
 	};
@@ -142,15 +137,14 @@ test("initalization of securityHandlers succeeds", (t) => {
 	fastify.register(fastifyOpenapiGlue, opts);
 	fastify.ready((err) => {
 		if (err) {
-			t.fail("got unexpected error");
+			assert.fail("got unexpected error");
 		} else {
-			t.pass("no unexpected error");
+			assert.ok(true, "no unexpected error");
 		}
 	});
 });
 
 test("security preHandler gets parameters passed", (t) => {
-	t.plan(8);
 	const opts = {
 		specification: testSpec,
 		service,
@@ -172,10 +166,10 @@ test("security preHandler gets parameters passed", (t) => {
 			url: "/v2/operationSecurity",
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.statusCode, 200);
-			t.equal(res.statusMessage, "OK");
-			t.equal(res.body, '{"response":"authentication succeeded!"}');
+			assert.ifError(err);
+			assert.equal(res.statusCode, 200);
+			assert.equal(res.statusMessage, "OK");
+			assert.equal(res.body, '{"response":"authentication succeeded!"}');
 		},
 	);
 
@@ -185,10 +179,10 @@ test("security preHandler gets parameters passed", (t) => {
 			url: "/v2/operationSecurityWithParameter",
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.statusCode, 200);
-			t.equal(res.statusMessage, "OK");
-			t.equal(res.body, '{"response":"skipped"}');
+			assert.ifError(err);
+			assert.equal(res.statusCode, 200);
+			assert.equal(res.statusMessage, "OK");
+			assert.equal(res.body, '{"response":"skipped"}');
 		},
 	);
 });

--- a/test/test-securityHandlers.v3.js
+++ b/test/test-securityHandlers.v3.js
@@ -1,4 +1,5 @@
-import { test } from "tap";
+import { test } from "node:test";
+import { strict as assert } from "node:assert/strict";
 import Fastify from "fastify";
 import fastifyOpenapiGlue from "../index.js";
 import { createRequire } from "module";
@@ -31,14 +32,13 @@ test("security handler registration succeeds", (t) => {
 		securityHandlers,
 	};
 
-	t.plan(1);
 	const fastify = Fastify(noStrict);
 	fastify.register(fastifyOpenapiGlue, opts);
 	fastify.ready((err) => {
 		if (err) {
-			t.fail("got unexpected error");
+			assert.fail("got unexpected error");
 		} else {
-			t.pass("no unexpected error");
+			assert.ok(true, "no unexpected error");
 		}
 	});
 });
@@ -52,10 +52,9 @@ test("security preHandler throws error", (t) => {
 		},
 	};
 
-	t.plan(4);
 	const fastify = Fastify();
 	fastify.setErrorHandler((err, req, reply) => {
-		t.equal(err.errors.length, 3);
+		assert.equal(err.errors.length, 3);
 		reply.code(err.statusCode).send(err);
 	});
 	fastify.register(fastifyOpenapiGlue, opts);
@@ -65,9 +64,9 @@ test("security preHandler throws error", (t) => {
 			url: "/operationSecurity",
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.statusCode, 401);
-			t.equal(res.statusMessage, "Unauthorized");
+			assert.ifError(err);
+			assert.equal(res.statusCode, 401);
+			assert.equal(res.statusMessage, "Unauthorized");
 		},
 	);
 });
@@ -83,7 +82,6 @@ test("security preHandler passes on succes", (t) => {
 		},
 	};
 
-	t.plan(3);
 	const fastify = Fastify();
 	fastify.register(fastifyOpenapiGlue, opts);
 
@@ -93,9 +91,9 @@ test("security preHandler passes on succes", (t) => {
 			url: "/operationSecurity",
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.statusCode, 200);
-			t.equal(res.statusMessage, "OK");
+			assert.ifError(err);
+			assert.equal(res.statusCode, 200);
+			assert.equal(res.statusMessage, "OK");
 		},
 	);
 });
@@ -107,7 +105,6 @@ test("security preHandler passes with empty handler", (t) => {
 		securityHandlers,
 	};
 
-	t.plan(3);
 	const fastify = Fastify();
 	fastify.register(fastifyOpenapiGlue, opts);
 
@@ -117,9 +114,9 @@ test("security preHandler passes with empty handler", (t) => {
 			url: "/operationSecurityEmptyHandler",
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.statusCode, 200);
-			t.equal(res.statusMessage, "OK");
+			assert.ifError(err);
+			assert.equal(res.statusCode, 200);
+			assert.equal(res.statusMessage, "OK");
 		},
 	);
 });
@@ -133,10 +130,9 @@ test("security preHandler handles missing handlers", (t) => {
 		},
 	};
 
-	t.plan(4);
 	const fastify = Fastify();
 	fastify.setErrorHandler((err, req, reply) => {
-		t.equal(err.errors.length, 3);
+		assert.equal(err.errors.length, 3);
 		reply.code(err.statusCode).send(err);
 	});
 	fastify.register(fastifyOpenapiGlue, opts);
@@ -146,33 +142,30 @@ test("security preHandler handles missing handlers", (t) => {
 			url: "/operationSecurity",
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.statusCode, 401);
-			t.equal(res.statusMessage, "Unauthorized");
+			assert.ifError(err);
+			assert.equal(res.statusCode, 401);
+			assert.equal(res.statusMessage, "Unauthorized");
 		},
 	);
 });
 
 test("invalid securityHandler definition throws error ", (t) => {
-	t.plan(1);
 	const fastify = Fastify();
 	fastify.register(fastifyOpenapiGlue, invalidSecurityOpts);
 	fastify.ready((err) => {
 		if (err) {
-			t.match(
+			assert.equal(
 				err.message,
 				"'securityHandlers' parameter must refer to an object",
 				"got expected error",
 			);
 		} else {
-			t.fail("missed expected error");
+			assert.fail("missed expected error");
 		}
 	});
 });
 
 test("initalization of securityHandlers succeeds", (t) => {
-	t.plan(2);
-
 	const opts = {
 		specification: testSpec,
 		service,
@@ -181,7 +174,7 @@ test("initalization of securityHandlers succeeds", (t) => {
 				const securitySchemeFromSpec = JSON.stringify(
 					testSpec.components.securitySchemes,
 				);
-				t.equal(JSON.stringify(securitySchemes), securitySchemeFromSpec);
+				assert.equal(JSON.stringify(securitySchemes), securitySchemeFromSpec);
 			},
 		},
 	};
@@ -190,15 +183,14 @@ test("initalization of securityHandlers succeeds", (t) => {
 	fastify.register(fastifyOpenapiGlue, opts);
 	fastify.ready((err) => {
 		if (err) {
-			t.fail("got unexpected error");
+			assert.fail("got unexpected error");
 		} else {
-			t.pass("no unexpected error");
+			assert.ok(true, "no unexpected error");
 		}
 	});
 });
 
 test("security preHandler gets parameters passed", (t) => {
-	t.plan(8);
 	const opts = {
 		specification: testSpec,
 		service,
@@ -220,10 +212,10 @@ test("security preHandler gets parameters passed", (t) => {
 			url: "/operationSecurity",
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.statusCode, 200);
-			t.equal(res.statusMessage, "OK");
-			t.equal(res.body, '{"response":"authentication succeeded!"}');
+			assert.ifError(err);
+			assert.equal(res.statusCode, 200);
+			assert.equal(res.statusMessage, "OK");
+			assert.equal(res.body, '{"response":"authentication succeeded!"}');
 		},
 	);
 
@@ -233,10 +225,10 @@ test("security preHandler gets parameters passed", (t) => {
 			url: "/operationSecurityWithParameter",
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.statusCode, 200);
-			t.equal(res.statusMessage, "OK");
-			t.equal(res.body, '{"response":"skipped"}');
+			assert.ifError(err);
+			assert.equal(res.statusCode, 200);
+			assert.equal(res.statusMessage, "OK");
+			assert.equal(res.body, '{"response":"skipped"}');
 		},
 	);
 });
@@ -250,10 +242,9 @@ test("security preHandler throws error with custom StatusCode", (t) => {
 		},
 	};
 
-	t.plan(4);
 	const fastify = Fastify();
 	fastify.setErrorHandler((err, req, reply) => {
-		t.equal(err.errors.length, 3);
+		assert.equal(err.errors.length, 3);
 		reply.code(err.statusCode).send(err);
 	});
 	fastify.register(fastifyOpenapiGlue, opts);
@@ -263,9 +254,9 @@ test("security preHandler throws error with custom StatusCode", (t) => {
 			url: "/operationSecurity",
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.statusCode, 451);
-			t.equal(res.statusMessage, "Unavailable For Legal Reasons");
+			assert.ifError(err);
+			assert.equal(res.statusCode, 451);
+			assert.equal(res.statusMessage, "Unavailable For Legal Reasons");
 		},
 	);
 });
@@ -279,10 +270,9 @@ test("security preHandler does not throw error when global security handler is o
 		},
 	};
 
-	t.plan(4);
 	const fastify = Fastify();
 	fastify.setErrorHandler((err, _req, reply) => {
-		t.equal(err.errors.length, 3);
+		assert.equal(err.errors.length, 3);
 		reply.code(err.statusCode).send(err);
 	});
 	fastify.register(fastifyOpenapiGlue, opts);
@@ -292,10 +282,10 @@ test("security preHandler does not throw error when global security handler is o
 			url: "/operationSecurityOverrideWithNoSecurity",
 		},
 		(err, res) => {
-			t.error(err);
-			t.equal(res.statusCode, 200);
-			t.equal(res.statusMessage, "OK");
-			t.equal(res.body, '{"response":"authentication succeeded!"}');
+			assert.ifError(err);
+			assert.equal(res.statusCode, 200);
+			assert.equal(res.statusMessage, "OK");
+			assert.equal(res.body, '{"response":"authentication succeeded!"}');
 		},
 	);
 });

--- a/test/test-swagger-noBasePath.v2.javascript.checksums.json
+++ b/test/test-swagger-noBasePath.v2.javascript.checksums.json
@@ -22,7 +22,7 @@
 		},
 		"testPlugin": {
 			"fileName": "test-plugin.js",
-			"checksum": "4abe118ae5a18de3820b54ee432180e02b11d674440d20e546998c5c27d683a8"
+			"checksum": "b93c6dff773636b86a116daa5ac5ebac1625d3ff9072aacac6814b850623236a"
 		},
 		"package": {
 			"fileName": "package.json",

--- a/test/test-swagger-noBasePath.v2.standaloneJS.checksums.json
+++ b/test/test-swagger-noBasePath.v2.standaloneJS.checksums.json
@@ -22,7 +22,7 @@
 		},
 		"testPlugin": {
 			"fileName": "test-plugin.js",
-			"checksum": "4abe118ae5a18de3820b54ee432180e02b11d674440d20e546998c5c27d683a8"
+			"checksum": "b93c6dff773636b86a116daa5ac5ebac1625d3ff9072aacac6814b850623236a"
 		},
 		"package": {
 			"fileName": "package.json",

--- a/test/test-swagger.v2.javascript.checksums.json
+++ b/test/test-swagger.v2.javascript.checksums.json
@@ -22,7 +22,7 @@
 		},
 		"testPlugin": {
 			"fileName": "test-plugin.js",
-			"checksum": "a7967600ff4085ab6d4a4c2b5541036c4a83457b12e406a09800c744eab511ad"
+			"checksum": "0b596e2ffbbc592bf49790db6429fbadfe37bcdf2aa8b213955b6d731a648376"
 		},
 		"package": {
 			"fileName": "package.json",

--- a/test/test-swagger.v2.standaloneJS.checksums.json
+++ b/test/test-swagger.v2.standaloneJS.checksums.json
@@ -22,7 +22,7 @@
 		},
 		"testPlugin": {
 			"fileName": "test-plugin.js",
-			"checksum": "a7967600ff4085ab6d4a4c2b5541036c4a83457b12e406a09800c744eab511ad"
+			"checksum": "0b596e2ffbbc592bf49790db6429fbadfe37bcdf2aa8b213955b6d731a648376"
 		},
 		"package": {
 			"fileName": "package.json",


### PR DESCRIPTION
Due to a bug in Node 16 we can't remove Tap in full, however it has been removed from all individual tests.
As soon as Node 16 is EOL we can remove Tap from the list of dependencies