### PR TITLE
fix: make Swagger generic parameters work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 ## [Unreleased]
 ### Changed
 
+## [4.3.1] 14-08-2023
+### Changed
+ - fix: make generic parameters work on v2 (swagger) spec
+ - updated dependencies
+    - c8               ^8.0.0  →   ^8.0.1
+    - fastify         ^4.17.0  →  ^4.21.0
+    - fastify-cli      ^5.7.1  →   ^5.8.0
+    - fastify-plugin   ^4.5.0  →   ^4.5.1
+    - tap             ^16.3.6  →  ^16.3.8
+
 ## [4.3.0] 17-06-2023
 ### Changed
  - chore: replaced Tap by Node test

--- a/examples/generated-javascript-project/package.json
+++ b/examples/generated-javascript-project/package.json
@@ -12,17 +12,17 @@
     "test": "test"
   },
   "dependencies": {
-    "fastify-plugin": "^4.5.0",
+    "fastify-plugin": "^4.5.1",
     "@seriousme/openapi-schema-validator": "^2.1.0",
     "js-yaml": "^4.1.0",
     "minimist": "^1.2.8",
     "fastify-openapi-glue": "^4.3.0"
   },
   "devDependencies": {
-    "fastify": "^4.17.0",
-    "fastify-cli": "^5.7.1",
-    "tap": "^16.3.6",
-    "c8": "^8.0.0",
+    "fastify": "^4.21.0",
+    "fastify-cli": "^5.8.0",
+    "tap": "^16.3.8",
+    "c8": "^8.0.1",
     "husky": "^8.0.3",
     "rome": "^12.1.3"
   }

--- a/examples/generated-standaloneJS-project/package.json
+++ b/examples/generated-standaloneJS-project/package.json
@@ -12,16 +12,16 @@
     "test": "test"
   },
   "dependencies": {
-    "fastify-plugin": "^4.5.0",
+    "fastify-plugin": "^4.5.1",
     "@seriousme/openapi-schema-validator": "^2.1.0",
     "js-yaml": "^4.1.0",
     "minimist": "^1.2.8"
   },
   "devDependencies": {
-    "fastify": "^4.17.0",
-    "fastify-cli": "^5.7.1",
-    "tap": "^16.3.6",
-    "c8": "^8.0.0",
+    "fastify": "^4.21.0",
+    "fastify-cli": "^5.8.0",
+    "tap": "^16.3.8",
+    "c8": "^8.0.1",
     "husky": "^8.0.3",
     "rome": "^12.1.3"
   }

--- a/lib/Parser.v2.js
+++ b/lib/Parser.v2.js
@@ -1,5 +1,5 @@
 // a class for parsing openapi V2 data into config data for fastify
-import { ParserBase, HttpOperations } from "./ParserBase.js";
+import { ParserBase } from "./ParserBase.js";
 
 export class ParserV2 extends ParserBase {
 	parseParams(data) {
@@ -108,50 +108,6 @@ export class ParserV2 extends ParserBase {
 		// remove loops from the schema so fastify wont break
 		this.removeRecursion(schema);
 		return schema;
-	}
-
-	processOperation(path, operation, operationSpec, genericSchema) {
-		const route = {
-			method: operation.toUpperCase(),
-			url: this.makeURL(path),
-			schema: this.makeSchema(genericSchema, operationSpec),
-			openapiPath: path,
-			operationId:
-				operationSpec.operationId || this.makeOperationId(operation, path),
-			openapiSource: operationSpec,
-			security: this.parseSecurity(
-				operationSpec.security || this.spec.security,
-			),
-		};
-
-		if (operationSpec["x-fastify-config"]) {
-			route.config = operationSpec["x-fastify-config"];
-		}
-
-		this.config.routes.push(route);
-	}
-
-	processPaths(paths) {
-		const copyItems = ["summary", "description"];
-		for (const path in paths) {
-			const genericSchema = {};
-			const pathSpec = paths[path];
-
-			this.copyProps(pathSpec, genericSchema, copyItems, true);
-			if (typeof pathSpec.parameters === "object") {
-				this.parseParameters(genericSchema, pathSpec.parameters);
-			}
-			for (const operation in pathSpec) {
-				if (HttpOperations.has(operation)) {
-					this.processOperation(
-						path,
-						operation,
-						pathSpec[operation],
-						genericSchema,
-					);
-				}
-			}
-		}
 	}
 
 	parse(spec) {

--- a/lib/Parser.v2.js
+++ b/lib/Parser.v2.js
@@ -1,5 +1,5 @@
 // a class for parsing openapi V2 data into config data for fastify
-import { ParserBase } from "./ParserBase.js";
+import { ParserBase, HttpOperations } from "./ParserBase.js";
 
 export class ParserV2 extends ParserBase {
 	parseParams(data) {
@@ -85,8 +85,8 @@ export class ParserV2 extends ParserBase {
 		return result;
 	}
 
-	makeSchema(data) {
-		const schema = {};
+	makeSchema(genericSchema, data) {
+		const schema = Object.assign({}, genericSchema);
 		const copyItems = [
 			"tags",
 			"summary",
@@ -110,28 +110,46 @@ export class ParserV2 extends ParserBase {
 		return schema;
 	}
 
-	processOperation(path, operation, data) {
+	processOperation(path, operation, operationSpec, genericSchema) {
 		const route = {
 			method: operation.toUpperCase(),
 			url: this.makeURL(path),
-			schema: this.makeSchema(data),
+			schema: this.makeSchema(genericSchema, operationSpec),
 			openapiPath: path,
-			operationId: data.operationId || this.makeOperationId(operation, path),
-			openapiSource: data,
-			security: this.parseSecurity(data.security || this.spec.security),
+			operationId:
+				operationSpec.operationId || this.makeOperationId(operation, path),
+			openapiSource: operationSpec,
+			security: this.parseSecurity(
+				operationSpec.security || this.spec.security,
+			),
 		};
 
-		if (data["x-fastify-config"]) {
-			route.config = data["x-fastify-config"];
+		if (operationSpec["x-fastify-config"]) {
+			route.config = operationSpec["x-fastify-config"];
 		}
 
 		this.config.routes.push(route);
 	}
 
 	processPaths(paths) {
+		const copyItems = ["summary", "description"];
 		for (const path in paths) {
-			for (const operation in paths[path]) {
-				this.processOperation(path, operation, paths[path][operation]);
+			const genericSchema = {};
+			const pathSpec = paths[path];
+
+			this.copyProps(pathSpec, genericSchema, copyItems, true);
+			if (typeof pathSpec.parameters === "object") {
+				this.parseParameters(genericSchema, pathSpec.parameters);
+			}
+			for (const operation in pathSpec) {
+				if (HttpOperations.has(operation)) {
+					this.processOperation(
+						path,
+						operation,
+						pathSpec[operation],
+						genericSchema,
+					);
+				}
 			}
 		}
 	}

--- a/lib/Parser.v3.js
+++ b/lib/Parser.v3.js
@@ -1,16 +1,6 @@
 // a class for parsing openapi v3 data into config data for fastify
 
-import { ParserBase } from "./ParserBase.js";
-
-const HttpOperations = new Set([
-	"delete",
-	"get",
-	"head",
-	"patch",
-	"post",
-	"put",
-	"options",
-]);
+import { ParserBase, HttpOperations } from "./ParserBase.js";
 
 function isExploding(item) {
 	const explode = item.explode ?? item.style === "form" ? true : false;
@@ -164,12 +154,12 @@ export class ParserV3 extends ParserBase {
 			if (typeof pathSpec.parameters === "object") {
 				this.parseParameters(genericSchema, pathSpec.parameters);
 			}
-			for (const pathItem in pathSpec) {
-				if (HttpOperations.has(pathItem)) {
+			for (const operation in pathSpec) {
+				if (HttpOperations.has(operation)) {
 					this.processOperation(
 						path,
-						pathItem,
-						pathSpec[pathItem],
+						operation,
+						pathSpec[operation],
 						genericSchema,
 					);
 				}

--- a/lib/Parser.v3.js
+++ b/lib/Parser.v3.js
@@ -1,6 +1,6 @@
 // a class for parsing openapi v3 data into config data for fastify
 
-import { ParserBase, HttpOperations } from "./ParserBase.js";
+import { ParserBase } from "./ParserBase.js";
 
 function isExploding(item) {
 	const explode = item.explode ?? item.style === "form" ? true : false;
@@ -121,50 +121,6 @@ export class ParserV3 extends ParserBase {
 
 		this.removeRecursion(schema);
 		return schema;
-	}
-
-	processOperation(path, operation, operationSpec, genericSchema) {
-		const route = {
-			method: operation.toUpperCase(),
-			url: this.makeURL(path),
-			schema: this.makeSchema(genericSchema, operationSpec),
-			openapiPath: path,
-			operationId:
-				operationSpec.operationId || this.makeOperationId(operation, path),
-			openapiSource: operationSpec,
-			security: this.parseSecurity(
-				operationSpec.security || this.spec.security,
-			),
-		};
-
-		if (operationSpec["x-fastify-config"]) {
-			route.config = operationSpec["x-fastify-config"];
-		}
-
-		this.config.routes.push(route);
-	}
-
-	processPaths(paths) {
-		const copyItems = ["summary", "description"];
-		for (const path in paths) {
-			const genericSchema = {};
-			const pathSpec = paths[path];
-
-			this.copyProps(pathSpec, genericSchema, copyItems, true);
-			if (typeof pathSpec.parameters === "object") {
-				this.parseParameters(genericSchema, pathSpec.parameters);
-			}
-			for (const operation in pathSpec) {
-				if (HttpOperations.has(operation)) {
-					this.processOperation(
-						path,
-						operation,
-						pathSpec[operation],
-						genericSchema,
-					);
-				}
-			}
-		}
 	}
 
 	parse(spec) {

--- a/lib/ParserBase.js
+++ b/lib/ParserBase.js
@@ -99,3 +99,13 @@ export class ParserBase {
 		}
 	}
 }
+
+export const HttpOperations = new Set([
+	"delete",
+	"get",
+	"head",
+	"patch",
+	"post",
+	"put",
+	"options",
+]);

--- a/lib/ParserBase.js
+++ b/lib/ParserBase.js
@@ -1,5 +1,15 @@
 // baseclass for the v2 and v3 parsers
 
+export const HttpOperations = new Set([
+	"delete",
+	"get",
+	"head",
+	"patch",
+	"post",
+	"put",
+	"options",
+]);
+
 export class ParserBase {
 	constructor() {
 		this.config = { generic: {}, routes: [], contentTypes: new Set() };
@@ -98,14 +108,48 @@ export class ParserBase {
 			}
 		}
 	}
-}
 
-export const HttpOperations = new Set([
-	"delete",
-	"get",
-	"head",
-	"patch",
-	"post",
-	"put",
-	"options",
-]);
+	processOperation(path, operation, operationSpec, genericSchema) {
+		const route = {
+			method: operation.toUpperCase(),
+			url: this.makeURL(path),
+			schema: this.makeSchema(genericSchema, operationSpec),
+			openapiPath: path,
+			operationId:
+				operationSpec.operationId || this.makeOperationId(operation, path),
+			openapiSource: operationSpec,
+			security: this.parseSecurity(
+				operationSpec.security || this.spec.security,
+			),
+		};
+
+		if (operationSpec["x-fastify-config"]) {
+			route.config = operationSpec["x-fastify-config"];
+		}
+
+		this.config.routes.push(route);
+	}
+
+	processPaths(paths) {
+		const copyItems = ["summary", "description"];
+		for (const path in paths) {
+			const genericSchema = {};
+			const pathSpec = paths[path];
+
+			this.copyProps(pathSpec, genericSchema, copyItems, true);
+			if (typeof pathSpec.parameters === "object") {
+				this.parseParameters(genericSchema, pathSpec.parameters);
+			}
+			for (const operation in pathSpec) {
+				if (HttpOperations.has(operation)) {
+					this.processOperation(
+						path,
+						operation,
+						pathSpec[operation],
+						genericSchema,
+					);
+				}
+			}
+		}
+	}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@seriousme/openapi-schema-validator": "^2.1.0",
-        "fastify-plugin": "^4.5.0",
+        "fastify-plugin": "^4.5.1",
         "js-yaml": "^4.1.0",
         "minimist": "^1.2.8"
       },
@@ -18,12 +18,12 @@
         "openapi-glue": "bin/openapi-glue-cli.js"
       },
       "devDependencies": {
-        "c8": "^8.0.0",
-        "fastify": "^4.17.0",
-        "fastify-cli": "^5.7.1",
+        "c8": "^8.0.1",
+        "fastify": "^4.21.0",
+        "fastify-cli": "^5.8.0",
         "husky": "^8.0.3",
         "rome": "^12.1.3",
-        "tap": "^16.3.6"
+        "tap": "^16.3.8"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -94,9 +94,9 @@
       }
     },
     "node_modules/@babel/core/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -160,9 +160,9 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -1020,9 +1020,9 @@
       "dev": true
     },
     "node_modules/c8": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/c8/-/c8-8.0.0.tgz",
-      "integrity": "sha512-XHA5vSfCLglAc0Xt8eLBZMv19lgiBSjnb1FLAQgnwkuhJYEonpilhEB4Ea3jPAbm0FhD6VVJrc0z73jPe7JyGQ==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/c8/-/c8-8.0.1.tgz",
+      "integrity": "sha512-EINpopxZNH1mETuI0DzRA4MZpAUH+IFiRhnmFD3vFr3vdrgxqi3VfE3KL0AIL+zDq8rC9bZqwM/VDmmoe04y7w==",
       "dev": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^0.2.3",
@@ -1030,13 +1030,13 @@
         "find-up": "^5.0.0",
         "foreground-child": "^2.0.0",
         "istanbul-lib-coverage": "^3.2.0",
-        "istanbul-lib-report": "^3.0.0",
-        "istanbul-reports": "^3.1.4",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.1.6",
         "rimraf": "^3.0.2",
         "test-exclude": "^6.0.0",
         "v8-to-istanbul": "^9.0.0",
-        "yargs": "^16.2.0",
-        "yargs-parser": "^20.2.9"
+        "yargs": "^17.7.2",
+        "yargs-parser": "^21.1.1"
       },
       "bin": {
         "c8": "bin/c8.js"
@@ -1182,9 +1182,9 @@
       }
     },
     "node_modules/colorette": {
-      "version": "2.0.19",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.19.tgz",
-      "integrity": "sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==",
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
       "dev": true
     },
     "node_modules/commist": {
@@ -1452,9 +1452,9 @@
       "dev": true
     },
     "node_modules/fastify": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/fastify/-/fastify-4.18.0.tgz",
-      "integrity": "sha512-L5o/2GEkBastQ3HV0dtKo7SUZ497Z1+q4fcqAoPyq6JCQ/8zdk1JQEoTQwnBWCp+EmA7AQa6mxNqSAEhzP0RwQ==",
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/fastify/-/fastify-4.21.0.tgz",
+      "integrity": "sha512-tsu4bcwE4HetxqW8prA5fbC9bKHMYDp7jGEDWyzK1l90a3uOaLoIcQbdGcWeODNLVJviQnzh1wvIjTZE3MJFEg==",
       "dev": true,
       "dependencies": {
         "@fastify/ajv-compiler": "^3.5.0",
@@ -1476,9 +1476,9 @@
       }
     },
     "node_modules/fastify-cli": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/fastify-cli/-/fastify-cli-5.7.1.tgz",
-      "integrity": "sha512-0FgQux1TK+zsRxVLDCF4F+x2ilHDeaJB2TouHIHWRS0+cM6aC+bBSqHva/myrlZs/1lQCAe294DvZkAuJyHySw==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/fastify-cli/-/fastify-cli-5.8.0.tgz",
+      "integrity": "sha512-8J1nej1nnF6UsgRv787rl9VkUjBnYVGXcbFvuAZ3LHP6mN8Sb7+0OBzcRs3SMO6qkRax89TqOUJWVNQHZXfixw==",
       "dev": true,
       "dependencies": {
         "@fastify/deepmerge": "^1.2.0",
@@ -1493,7 +1493,7 @@
         "help-me": "^4.0.1",
         "is-docker": "^2.0.0",
         "make-promises-safe": "^5.1.0",
-        "pino-pretty": "^9.0.0",
+        "pino-pretty": "^10.1.0",
         "pkg-up": "^3.1.0",
         "resolve-from": "^5.0.0",
         "semver": "^7.3.5",
@@ -1503,19 +1503,10 @@
         "fastify": "cli.js"
       }
     },
-    "node_modules/fastify-cli/node_modules/yargs-parser": {
-      "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/fastify-plugin": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-4.5.0.tgz",
-      "integrity": "sha512-79ak0JxddO0utAXAQ5ccKhvs6vX2MGyHHMMsmZkBANrq3hXc1CHzvNPHOcvTsVMEPl5I+NT+RO4YKMGehOfSIg=="
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-4.5.1.tgz",
+      "integrity": "sha512-stRHYGeuqpEZTL1Ef0Ovr2ltazUT9g844X5z/zEBFLG8RYlpDiOCIG+ATvYEp+/zmc7sN29mcIMp8gvYplYPIQ=="
     },
     "node_modules/fastq": {
       "version": "1.15.0",
@@ -2020,9 +2011,9 @@
       }
     },
     "node_modules/istanbul-lib-instrument/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -2046,17 +2037,32 @@
       }
     },
     "node_modules/istanbul-lib-report": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
-      "integrity": "sha512-wcdi+uAKzfiGT2abPpKZ0hSU1rGQjUQnLvtY5MpQ7QCTahD3VODhcu4wcfY1YtkGaDD5yuydOLINXsfbus9ROw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
       "dev": true,
       "dependencies": {
         "istanbul-lib-coverage": "^3.0.0",
-        "make-dir": "^3.0.0",
+        "make-dir": "^4.0.0",
         "supports-color": "^7.1.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/istanbul-lib-source-maps": {
@@ -2074,9 +2080,9 @@
       }
     },
     "node_modules/istanbul-reports": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.5.tgz",
-      "integrity": "sha512-nUsEMa9pBt/NOHqbcbeJEgqIlY/K7rVWUX6Lql2orY5e9roQOthbR3vtY4zzf2orPELg80fnxxk9zUyPlgwD1w==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.6.tgz",
+      "integrity": "sha512-TLgnMkKg3iTDsQ9PbPTdpfAK2DzjF9mqUG7RMgcQl8oFjad8ob4laGxv5XV5U9MAfx8D6tSJiUyuAwzLicaxlg==",
       "dev": true,
       "dependencies": {
         "html-escaper": "^2.0.0",
@@ -2240,9 +2246,9 @@
       }
     },
     "node_modules/make-dir/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -2748,9 +2754,9 @@
       }
     },
     "node_modules/pino-pretty": {
-      "version": "9.4.0",
-      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-9.4.0.tgz",
-      "integrity": "sha512-NIudkNLxnl7MGj1XkvsqVyRgo6meFP82ECXF2PlOI+9ghmbGuBUUqKJ7IZPIxpJw4vhhSva0IuiDSAuGh6TV9g==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-10.2.0.tgz",
+      "integrity": "sha512-tRvpyEmGtc2D+Lr3FulIZ+R1baggQ4S3xD2Ar93KixFEDx6SEAUP3W5aYuEw1C73d6ROrNcB2IXLteW8itlwhA==",
       "dev": true,
       "dependencies": {
         "colorette": "^2.0.7",
@@ -2773,15 +2779,16 @@
       }
     },
     "node_modules/pino-pretty/node_modules/readable-stream": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.3.0.tgz",
-      "integrity": "sha512-MuEnA0lbSi7JS8XM+WNJlWZkHAAdm7gETHdFK//Q/mChGyj2akEFtdLZh32jSdkWGbRwCW9pn6g3LWDdDeZnBQ==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.4.2.tgz",
+      "integrity": "sha512-Lk/fICSyIhodxy1IDK2HazkeGjSmezAWX2egdtJnYhtzKEsBPJowlI6F6LPb5tqIQILrMbx22S5o3GuJavPusA==",
       "dev": true,
       "dependencies": {
         "abort-controller": "^3.0.0",
         "buffer": "^6.0.3",
         "events": "^3.3.0",
-        "process": "^0.11.10"
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -3221,9 +3228,9 @@
       "dev": true
     },
     "node_modules/semver": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz",
-      "integrity": "sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -3415,9 +3422,9 @@
       }
     },
     "node_modules/tap": {
-      "version": "16.3.7",
-      "resolved": "https://registry.npmjs.org/tap/-/tap-16.3.7.tgz",
-      "integrity": "sha512-AaovVsfXVKcIf9eD1NxgwIqSDz5LauvybTpS6bjAKVYqz3+iavHC1abwxTkXmswb2n7eq8qKLt8DvY3D6iWcYA==",
+      "version": "16.3.8",
+      "resolved": "https://registry.npmjs.org/tap/-/tap-16.3.8.tgz",
+      "integrity": "sha512-ARpCLtOFST37MholnZm7JMFikGq0x/T9uBdZH83iuddPNgwDTZQiD8+4x7VABUfVWS0ozKUkmHZ5OOzMI3fLPg==",
       "bundleDependencies": [
         "ink",
         "treport",
@@ -3600,7 +3607,7 @@
       }
     },
     "node_modules/tap/node_modules/@babel/compat-data": {
-      "version": "7.22.5",
+      "version": "7.22.9",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -3609,26 +3616,26 @@
       }
     },
     "node_modules/tap/node_modules/@babel/core": {
-      "version": "7.22.5",
+      "version": "7.22.9",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.22.5",
-        "@babel/generator": "^7.22.5",
-        "@babel/helper-compilation-targets": "^7.22.5",
-        "@babel/helper-module-transforms": "^7.22.5",
-        "@babel/helpers": "^7.22.5",
-        "@babel/parser": "^7.22.5",
+        "@babel/generator": "^7.22.9",
+        "@babel/helper-compilation-targets": "^7.22.9",
+        "@babel/helper-module-transforms": "^7.22.9",
+        "@babel/helpers": "^7.22.6",
+        "@babel/parser": "^7.22.7",
         "@babel/template": "^7.22.5",
-        "@babel/traverse": "^7.22.5",
+        "@babel/traverse": "^7.22.8",
         "@babel/types": "^7.22.5",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
         "json5": "^2.2.2",
-        "semver": "^6.3.0"
+        "semver": "^6.3.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -3639,7 +3646,7 @@
       }
     },
     "node_modules/tap/node_modules/@babel/generator": {
-      "version": "7.22.5",
+      "version": "7.22.9",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -3666,16 +3673,16 @@
       }
     },
     "node_modules/tap/node_modules/@babel/helper-compilation-targets": {
-      "version": "7.22.5",
+      "version": "7.22.9",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.22.5",
+        "@babel/compat-data": "^7.22.9",
         "@babel/helper-validator-option": "^7.22.5",
-        "browserslist": "^4.21.3",
+        "browserslist": "^4.21.9",
         "lru-cache": "^5.1.1",
-        "semver": "^6.3.0"
+        "semver": "^6.3.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -3731,7 +3738,7 @@
       }
     },
     "node_modules/tap/node_modules/@babel/helper-module-transforms": {
-      "version": "7.22.5",
+      "version": "7.22.9",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -3739,14 +3746,14 @@
         "@babel/helper-environment-visitor": "^7.22.5",
         "@babel/helper-module-imports": "^7.22.5",
         "@babel/helper-simple-access": "^7.22.5",
-        "@babel/helper-split-export-declaration": "^7.22.5",
-        "@babel/helper-validator-identifier": "^7.22.5",
-        "@babel/template": "^7.22.5",
-        "@babel/traverse": "^7.22.5",
-        "@babel/types": "^7.22.5"
+        "@babel/helper-split-export-declaration": "^7.22.6",
+        "@babel/helper-validator-identifier": "^7.22.5"
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
       }
     },
     "node_modules/tap/node_modules/@babel/helper-plugin-utils": {
@@ -3771,7 +3778,7 @@
       }
     },
     "node_modules/tap/node_modules/@babel/helper-split-export-declaration": {
-      "version": "7.22.5",
+      "version": "7.22.6",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -3810,13 +3817,13 @@
       }
     },
     "node_modules/tap/node_modules/@babel/helpers": {
-      "version": "7.22.5",
+      "version": "7.22.6",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.22.5",
-        "@babel/traverse": "^7.22.5",
+        "@babel/traverse": "^7.22.6",
         "@babel/types": "^7.22.5"
       },
       "engines": {
@@ -3838,7 +3845,7 @@
       }
     },
     "node_modules/tap/node_modules/@babel/parser": {
-      "version": "7.22.5",
+      "version": "7.22.7",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -3959,18 +3966,18 @@
       }
     },
     "node_modules/tap/node_modules/@babel/traverse": {
-      "version": "7.22.5",
+      "version": "7.22.8",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.22.5",
-        "@babel/generator": "^7.22.5",
+        "@babel/generator": "^7.22.7",
         "@babel/helper-environment-visitor": "^7.22.5",
         "@babel/helper-function-name": "^7.22.5",
         "@babel/helper-hoist-variables": "^7.22.5",
-        "@babel/helper-split-export-declaration": "^7.22.5",
-        "@babel/parser": "^7.22.5",
+        "@babel/helper-split-export-declaration": "^7.22.6",
+        "@babel/parser": "^7.22.7",
         "@babel/types": "^7.22.5",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
@@ -4253,7 +4260,7 @@
       }
     },
     "node_modules/tap/node_modules/caniuse-lite": {
-      "version": "1.0.30001506",
+      "version": "1.0.30001517",
       "dev": true,
       "funding": [
         {
@@ -4423,7 +4430,7 @@
       }
     },
     "node_modules/tap/node_modules/electron-to-chromium": {
-      "version": "1.4.438",
+      "version": "1.4.477",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
@@ -4843,7 +4850,7 @@
       "license": "MIT"
     },
     "node_modules/tap/node_modules/node-releases": {
-      "version": "2.0.12",
+      "version": "2.0.13",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
@@ -4985,7 +4992,7 @@
       }
     },
     "node_modules/tap/node_modules/react-devtools-core": {
-      "version": "4.27.8",
+      "version": "4.28.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -5068,7 +5075,7 @@
       }
     },
     "node_modules/tap/node_modules/semver": {
-      "version": "6.3.0",
+      "version": "6.3.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -5784,30 +5791,44 @@
       }
     },
     "node_modules/yargs": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
       "dev": true,
       "dependencies": {
-        "cliui": "^7.0.2",
+        "cliui": "^8.0.1",
         "escalade": "^3.1.1",
         "get-caller-file": "^2.0.5",
         "require-directory": "^2.1.1",
-        "string-width": "^4.2.0",
+        "string-width": "^4.2.3",
         "y18n": "^5.0.5",
-        "yargs-parser": "^20.2.2"
+        "yargs-parser": "^21.1.1"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       }
     },
     "node_modules/yargs-parser": {
-      "version": "20.2.9",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "dev": true,
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs/node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/yocto-queue": {
@@ -5873,9 +5894,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
           "dev": true
         }
       }
@@ -5928,9 +5949,9 @@
           }
         },
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
           "dev": true
         },
         "yallist": {
@@ -6554,9 +6575,9 @@
       "dev": true
     },
     "c8": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/c8/-/c8-8.0.0.tgz",
-      "integrity": "sha512-XHA5vSfCLglAc0Xt8eLBZMv19lgiBSjnb1FLAQgnwkuhJYEonpilhEB4Ea3jPAbm0FhD6VVJrc0z73jPe7JyGQ==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/c8/-/c8-8.0.1.tgz",
+      "integrity": "sha512-EINpopxZNH1mETuI0DzRA4MZpAUH+IFiRhnmFD3vFr3vdrgxqi3VfE3KL0AIL+zDq8rC9bZqwM/VDmmoe04y7w==",
       "dev": true,
       "requires": {
         "@bcoe/v8-coverage": "^0.2.3",
@@ -6564,13 +6585,13 @@
         "find-up": "^5.0.0",
         "foreground-child": "^2.0.0",
         "istanbul-lib-coverage": "^3.2.0",
-        "istanbul-lib-report": "^3.0.0",
-        "istanbul-reports": "^3.1.4",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.1.6",
         "rimraf": "^3.0.2",
         "test-exclude": "^6.0.0",
         "v8-to-istanbul": "^9.0.0",
-        "yargs": "^16.2.0",
-        "yargs-parser": "^20.2.9"
+        "yargs": "^17.7.2",
+        "yargs-parser": "^21.1.1"
       }
     },
     "caching-transform": {
@@ -6668,9 +6689,9 @@
       "dev": true
     },
     "colorette": {
-      "version": "2.0.19",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.19.tgz",
-      "integrity": "sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==",
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
       "dev": true
     },
     "commist": {
@@ -6884,9 +6905,9 @@
       "dev": true
     },
     "fastify": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/fastify/-/fastify-4.18.0.tgz",
-      "integrity": "sha512-L5o/2GEkBastQ3HV0dtKo7SUZ497Z1+q4fcqAoPyq6JCQ/8zdk1JQEoTQwnBWCp+EmA7AQa6mxNqSAEhzP0RwQ==",
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/fastify/-/fastify-4.21.0.tgz",
+      "integrity": "sha512-tsu4bcwE4HetxqW8prA5fbC9bKHMYDp7jGEDWyzK1l90a3uOaLoIcQbdGcWeODNLVJviQnzh1wvIjTZE3MJFEg==",
       "dev": true,
       "requires": {
         "@fastify/ajv-compiler": "^3.5.0",
@@ -6908,9 +6929,9 @@
       }
     },
     "fastify-cli": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/fastify-cli/-/fastify-cli-5.7.1.tgz",
-      "integrity": "sha512-0FgQux1TK+zsRxVLDCF4F+x2ilHDeaJB2TouHIHWRS0+cM6aC+bBSqHva/myrlZs/1lQCAe294DvZkAuJyHySw==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/fastify-cli/-/fastify-cli-5.8.0.tgz",
+      "integrity": "sha512-8J1nej1nnF6UsgRv787rl9VkUjBnYVGXcbFvuAZ3LHP6mN8Sb7+0OBzcRs3SMO6qkRax89TqOUJWVNQHZXfixw==",
       "dev": true,
       "requires": {
         "@fastify/deepmerge": "^1.2.0",
@@ -6925,25 +6946,17 @@
         "help-me": "^4.0.1",
         "is-docker": "^2.0.0",
         "make-promises-safe": "^5.1.0",
-        "pino-pretty": "^9.0.0",
+        "pino-pretty": "^10.1.0",
         "pkg-up": "^3.1.0",
         "resolve-from": "^5.0.0",
         "semver": "^7.3.5",
         "yargs-parser": "^21.1.1"
-      },
-      "dependencies": {
-        "yargs-parser": {
-          "version": "21.1.1",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-          "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-          "dev": true
-        }
       }
     },
     "fastify-plugin": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-4.5.0.tgz",
-      "integrity": "sha512-79ak0JxddO0utAXAQ5ccKhvs6vX2MGyHHMMsmZkBANrq3hXc1CHzvNPHOcvTsVMEPl5I+NT+RO4YKMGehOfSIg=="
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-4.5.1.tgz",
+      "integrity": "sha512-stRHYGeuqpEZTL1Ef0Ovr2ltazUT9g844X5z/zEBFLG8RYlpDiOCIG+ATvYEp+/zmc7sN29mcIMp8gvYplYPIQ=="
     },
     "fastq": {
       "version": "1.15.0",
@@ -7290,9 +7303,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
           "dev": true
         }
       }
@@ -7312,14 +7325,25 @@
       }
     },
     "istanbul-lib-report": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
-      "integrity": "sha512-wcdi+uAKzfiGT2abPpKZ0hSU1rGQjUQnLvtY5MpQ7QCTahD3VODhcu4wcfY1YtkGaDD5yuydOLINXsfbus9ROw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
       "dev": true,
       "requires": {
         "istanbul-lib-coverage": "^3.0.0",
-        "make-dir": "^3.0.0",
+        "make-dir": "^4.0.0",
         "supports-color": "^7.1.0"
+      },
+      "dependencies": {
+        "make-dir": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+          "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+          "dev": true,
+          "requires": {
+            "semver": "^7.5.3"
+          }
+        }
       }
     },
     "istanbul-lib-source-maps": {
@@ -7334,9 +7358,9 @@
       }
     },
     "istanbul-reports": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.5.tgz",
-      "integrity": "sha512-nUsEMa9pBt/NOHqbcbeJEgqIlY/K7rVWUX6Lql2orY5e9roQOthbR3vtY4zzf2orPELg80fnxxk9zUyPlgwD1w==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.6.tgz",
+      "integrity": "sha512-TLgnMkKg3iTDsQ9PbPTdpfAK2DzjF9mqUG7RMgcQl8oFjad8ob4laGxv5XV5U9MAfx8D6tSJiUyuAwzLicaxlg==",
       "dev": true,
       "requires": {
         "html-escaper": "^2.0.0",
@@ -7455,9 +7479,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
           "dev": true
         }
       }
@@ -7858,9 +7882,9 @@
       }
     },
     "pino-pretty": {
-      "version": "9.4.0",
-      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-9.4.0.tgz",
-      "integrity": "sha512-NIudkNLxnl7MGj1XkvsqVyRgo6meFP82ECXF2PlOI+9ghmbGuBUUqKJ7IZPIxpJw4vhhSva0IuiDSAuGh6TV9g==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-10.2.0.tgz",
+      "integrity": "sha512-tRvpyEmGtc2D+Lr3FulIZ+R1baggQ4S3xD2Ar93KixFEDx6SEAUP3W5aYuEw1C73d6ROrNcB2IXLteW8itlwhA==",
       "dev": true,
       "requires": {
         "colorette": "^2.0.7",
@@ -7880,15 +7904,16 @@
       },
       "dependencies": {
         "readable-stream": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.3.0.tgz",
-          "integrity": "sha512-MuEnA0lbSi7JS8XM+WNJlWZkHAAdm7gETHdFK//Q/mChGyj2akEFtdLZh32jSdkWGbRwCW9pn6g3LWDdDeZnBQ==",
+          "version": "4.4.2",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.4.2.tgz",
+          "integrity": "sha512-Lk/fICSyIhodxy1IDK2HazkeGjSmezAWX2egdtJnYhtzKEsBPJowlI6F6LPb5tqIQILrMbx22S5o3GuJavPusA==",
           "dev": true,
           "requires": {
             "abort-controller": "^3.0.0",
             "buffer": "^6.0.3",
             "events": "^3.3.0",
-            "process": "^0.11.10"
+            "process": "^0.11.10",
+            "string_decoder": "^1.3.0"
           }
         }
       }
@@ -8215,9 +8240,9 @@
       "dev": true
     },
     "semver": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz",
-      "integrity": "sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
       "requires": {
         "lru-cache": "^6.0.0"
@@ -8370,9 +8395,9 @@
       }
     },
     "tap": {
-      "version": "16.3.7",
-      "resolved": "https://registry.npmjs.org/tap/-/tap-16.3.7.tgz",
-      "integrity": "sha512-AaovVsfXVKcIf9eD1NxgwIqSDz5LauvybTpS6bjAKVYqz3+iavHC1abwxTkXmswb2n7eq8qKLt8DvY3D6iWcYA==",
+      "version": "16.3.8",
+      "resolved": "https://registry.npmjs.org/tap/-/tap-16.3.8.tgz",
+      "integrity": "sha512-ARpCLtOFST37MholnZm7JMFikGq0x/T9uBdZH83iuddPNgwDTZQiD8+4x7VABUfVWS0ozKUkmHZ5OOzMI3fLPg==",
       "dev": true,
       "requires": {
         "@isaacs/import-jsx": "^4.0.1",
@@ -8421,34 +8446,34 @@
           }
         },
         "@babel/compat-data": {
-          "version": "7.22.5",
+          "version": "7.22.9",
           "bundled": true,
           "dev": true
         },
         "@babel/core": {
-          "version": "7.22.5",
+          "version": "7.22.9",
           "bundled": true,
           "dev": true,
           "requires": {
             "@ampproject/remapping": "^2.2.0",
             "@babel/code-frame": "^7.22.5",
-            "@babel/generator": "^7.22.5",
-            "@babel/helper-compilation-targets": "^7.22.5",
-            "@babel/helper-module-transforms": "^7.22.5",
-            "@babel/helpers": "^7.22.5",
-            "@babel/parser": "^7.22.5",
+            "@babel/generator": "^7.22.9",
+            "@babel/helper-compilation-targets": "^7.22.9",
+            "@babel/helper-module-transforms": "^7.22.9",
+            "@babel/helpers": "^7.22.6",
+            "@babel/parser": "^7.22.7",
             "@babel/template": "^7.22.5",
-            "@babel/traverse": "^7.22.5",
+            "@babel/traverse": "^7.22.8",
             "@babel/types": "^7.22.5",
             "convert-source-map": "^1.7.0",
             "debug": "^4.1.0",
             "gensync": "^1.0.0-beta.2",
             "json5": "^2.2.2",
-            "semver": "^6.3.0"
+            "semver": "^6.3.1"
           }
         },
         "@babel/generator": {
-          "version": "7.22.5",
+          "version": "7.22.9",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -8467,15 +8492,15 @@
           }
         },
         "@babel/helper-compilation-targets": {
-          "version": "7.22.5",
+          "version": "7.22.9",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@babel/compat-data": "^7.22.5",
+            "@babel/compat-data": "^7.22.9",
             "@babel/helper-validator-option": "^7.22.5",
-            "browserslist": "^4.21.3",
+            "browserslist": "^4.21.9",
             "lru-cache": "^5.1.1",
-            "semver": "^6.3.0"
+            "semver": "^6.3.1"
           }
         },
         "@babel/helper-environment-visitor": {
@@ -8509,18 +8534,15 @@
           }
         },
         "@babel/helper-module-transforms": {
-          "version": "7.22.5",
+          "version": "7.22.9",
           "bundled": true,
           "dev": true,
           "requires": {
             "@babel/helper-environment-visitor": "^7.22.5",
             "@babel/helper-module-imports": "^7.22.5",
             "@babel/helper-simple-access": "^7.22.5",
-            "@babel/helper-split-export-declaration": "^7.22.5",
-            "@babel/helper-validator-identifier": "^7.22.5",
-            "@babel/template": "^7.22.5",
-            "@babel/traverse": "^7.22.5",
-            "@babel/types": "^7.22.5"
+            "@babel/helper-split-export-declaration": "^7.22.6",
+            "@babel/helper-validator-identifier": "^7.22.5"
           }
         },
         "@babel/helper-plugin-utils": {
@@ -8537,7 +8559,7 @@
           }
         },
         "@babel/helper-split-export-declaration": {
-          "version": "7.22.5",
+          "version": "7.22.6",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -8560,12 +8582,12 @@
           "dev": true
         },
         "@babel/helpers": {
-          "version": "7.22.5",
+          "version": "7.22.6",
           "bundled": true,
           "dev": true,
           "requires": {
             "@babel/template": "^7.22.5",
-            "@babel/traverse": "^7.22.5",
+            "@babel/traverse": "^7.22.6",
             "@babel/types": "^7.22.5"
           }
         },
@@ -8580,7 +8602,7 @@
           }
         },
         "@babel/parser": {
-          "version": "7.22.5",
+          "version": "7.22.7",
           "bundled": true,
           "dev": true
         },
@@ -8651,17 +8673,17 @@
           }
         },
         "@babel/traverse": {
-          "version": "7.22.5",
+          "version": "7.22.8",
           "bundled": true,
           "dev": true,
           "requires": {
             "@babel/code-frame": "^7.22.5",
-            "@babel/generator": "^7.22.5",
+            "@babel/generator": "^7.22.7",
             "@babel/helper-environment-visitor": "^7.22.5",
             "@babel/helper-function-name": "^7.22.5",
             "@babel/helper-hoist-variables": "^7.22.5",
-            "@babel/helper-split-export-declaration": "^7.22.5",
-            "@babel/parser": "^7.22.5",
+            "@babel/helper-split-export-declaration": "^7.22.6",
+            "@babel/parser": "^7.22.7",
             "@babel/types": "^7.22.5",
             "debug": "^4.1.0",
             "globals": "^11.1.0"
@@ -8849,7 +8871,7 @@
           "dev": true
         },
         "caniuse-lite": {
-          "version": "1.0.30001506",
+          "version": "1.0.30001517",
           "bundled": true,
           "dev": true
         },
@@ -8954,7 +8976,7 @@
           }
         },
         "electron-to-chromium": {
-          "version": "1.4.438",
+          "version": "1.4.477",
           "bundled": true,
           "dev": true
         },
@@ -9228,7 +9250,7 @@
           "dev": true
         },
         "node-releases": {
-          "version": "2.0.12",
+          "version": "2.0.13",
           "bundled": true,
           "dev": true
         },
@@ -9317,7 +9339,7 @@
           }
         },
         "react-devtools-core": {
-          "version": "4.27.8",
+          "version": "4.28.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -9375,7 +9397,7 @@
           }
         },
         "semver": {
-          "version": "6.3.0",
+          "version": "6.3.1",
           "bundled": true,
           "dev": true
         },
@@ -9945,24 +9967,37 @@
       "dev": true
     },
     "yargs": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
       "dev": true,
       "requires": {
-        "cliui": "^7.0.2",
+        "cliui": "^8.0.1",
         "escalade": "^3.1.1",
         "get-caller-file": "^2.0.5",
         "require-directory": "^2.1.1",
-        "string-width": "^4.2.0",
+        "string-width": "^4.2.3",
         "y18n": "^5.0.5",
-        "yargs-parser": "^20.2.2"
+        "yargs-parser": "^21.1.1"
+      },
+      "dependencies": {
+        "cliui": {
+          "version": "8.0.1",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+          "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+          "dev": true,
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.1",
+            "wrap-ansi": "^7.0.0"
+          }
+        }
       }
     },
     "yargs-parser": {
-      "version": "20.2.9",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "dev": true
     },
     "yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@seriousme/openapi-schema-validator": "^2.1.0",
-    "fastify-plugin": "^4.5.0",
+    "fastify-plugin": "^4.5.1",
     "js-yaml": "^4.1.0",
     "minimist": "^1.2.8"
   },
@@ -39,12 +39,12 @@
     "bin": "./bin"
   },
   "devDependencies": {
-    "c8": "^8.0.0",
-    "fastify": "^4.17.0",
-    "fastify-cli": "^5.7.1",
+    "c8": "^8.0.1",
+    "fastify": "^4.21.0",
+    "fastify-cli": "^5.8.0",
     "husky": "^8.0.3",
     "rome": "^12.1.3",
-    "tap": "^16.3.6"
+    "tap": "^16.3.8"
   },
   "repository": {
     "type": "git",

--- a/test/test-plugin.v2.js
+++ b/test/test-plugin.v2.js
@@ -9,6 +9,9 @@ const localFile = (fileName) => new URL(fileName, import.meta.url).pathname;
 const testSpec = await importJSON("./test-swagger.v2.json");
 const petStoreSpec = await importJSON("./petstore-swagger.v2.json");
 const testSpecYAML = localFile("./test-swagger.v2.yaml");
+const genericPathItemsSpec = await importJSON(
+	"./test-swagger-v2-generic-path-items.json",
+);
 import { Service } from "./service.js";
 const serviceHandlers = new Service();
 
@@ -47,6 +50,11 @@ const missingServiceOpts = {
 
 const petStoreOpts = {
 	specification: petStoreSpec,
+	serviceHandlers,
+};
+
+const genericPathItemsOpts = {
+	specification: genericPathItemsSpec,
 	serviceHandlers,
 };
 
@@ -306,6 +314,38 @@ test("x-fastify-config is applied", (t) => {
 		},
 		() => {
 			assert.ok(true);
+		},
+	);
+});
+
+test("generic path parameters work", (t) => {
+	const fastify = Fastify();
+	fastify.register(fastifyOpenapiGlue, genericPathItemsOpts);
+
+	fastify.inject(
+		{
+			method: "GET",
+			url: "/pathParam/2",
+		},
+		(err, res) => {
+			assert.ifError(err);
+			assert.equal(res.statusCode, 200);
+		},
+	);
+});
+
+test("generic path parameters override works", (t) => {
+	const fastify = Fastify();
+	fastify.register(fastifyOpenapiGlue, genericPathItemsOpts);
+
+	fastify.inject(
+		{
+			method: "GET",
+			url: "/noParam",
+		},
+		(err, res) => {
+			assert.ifError(err);
+			assert.equal(res.statusCode, 200);
 		},
 	);
 });

--- a/test/test-swagger-v2-generic-path-items.json
+++ b/test/test-swagger-v2-generic-path-items.json
@@ -1,0 +1,64 @@
+{
+	"swagger": "2.0",
+	"info": {
+		"title": "Test swagger",
+		"description": "testing the fastify swagger api",
+		"version": "0.1.0"
+	},
+	"host": "localhost",
+	"paths": {
+		"/pathParam/{id}": {
+			"parameters": [
+				{
+					"name": "id",
+					"in": "path",
+					"required": true,
+					"type": "string"
+				}
+			],
+			"get": {
+				"operationId": "getPathParam",
+				"summary": "Test path parameters",
+				"parameters": [
+					{
+						"name": "id",
+						"in": "path",
+						"required": true,
+						"type": "integer"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "ok"
+					}
+				}
+			}
+		},
+		"/noParam": {
+			"parameters": [
+				{
+					"name": "id",
+					"in": "query",
+					"required": true,
+					"type": "string"
+				}
+			],
+			"get": {
+				"operationId": "getNoParam",
+				"summary": "Test path parameters",
+				"parameters": [
+					{
+						"name": "id",
+						"in": "query",
+						"type": "integer"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "ok"
+					}
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
This PR fixes #504 and updates the following dependencies:
- c8               ^8.0.0  →   ^8.0.1
- fastify         ^4.17.0  →  ^4.21.0
- fastify-cli      ^5.7.1  →   ^5.8.0
- fastify-plugin   ^4.5.0  →   ^4.5.1
- tap             ^16.3.6  →  ^16.3.8