### PR TITLE
fix: make additional validation for v2 non-body parameters work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## [Unreleased]
 ### Changed
 
+## [4.3.2] 17-08-2023
+### Changed
+ - fix: make additional validation for v2 non-body parameters work
+
 ## [4.3.1] 14-08-2023
 ### Changed
  - fix: make generic parameters work on v2 (swagger) spec

--- a/examples/generated-javascript-project/package.json
+++ b/examples/generated-javascript-project/package.json
@@ -16,7 +16,7 @@
     "@seriousme/openapi-schema-validator": "^2.1.0",
     "js-yaml": "^4.1.0",
     "minimist": "^1.2.8",
-    "fastify-openapi-glue": "^4.3.0"
+    "fastify-openapi-glue": "^4.3.1"
   },
   "devDependencies": {
     "fastify": "^4.21.0",

--- a/examples/generated-javascript-project/service.js
+++ b/examples/generated-javascript-project/service.js
@@ -148,6 +148,14 @@ export class Service {
 	//     status:
 	//       description: Status values that need to be considered for filter
 	//       type: array
+	//       items:
+	//         type: string
+	//         enum:
+	//           - available
+	//           - pending
+	//           - sold
+	//         default: available
+	//       collectionFormat: multi
 	//   required:
 	//     - status
 	//
@@ -227,6 +235,9 @@ export class Service {
 	//     tags:
 	//       description: Tags to filter by
 	//       type: array
+	//       items:
+	//         type: string
+	//       collectionFormat: multi
 	//   required:
 	//     - tags
 	//
@@ -306,6 +317,7 @@ export class Service {
 	//     petId:
 	//       description: ID of pet to return
 	//       type: integer
+	//       format: int64
 	//   required:
 	//     - petId
 	//
@@ -385,6 +397,7 @@ export class Service {
 	//     petId:
 	//       description: ID of pet that needs to be updated
 	//       type: integer
+	//       format: int64
 	//   required:
 	//     - petId
 	//
@@ -423,6 +436,7 @@ export class Service {
 	//     petId:
 	//       description: Pet id to delete
 	//       type: integer
+	//       format: int64
 	//   required:
 	//     - petId
 	//
@@ -447,6 +461,7 @@ export class Service {
 	//     petId:
 	//       description: ID of pet to update
 	//       type: integer
+	//       format: int64
 	//   required:
 	//     - petId
 	//
@@ -577,6 +592,9 @@ export class Service {
 	//     orderId:
 	//       description: ID of pet that needs to be fetched
 	//       type: integer
+	//       maximum: 10
+	//       minimum: 1
+	//       format: int64
 	//   required:
 	//     - orderId
 	//
@@ -630,6 +648,8 @@ export class Service {
 	//     orderId:
 	//       description: ID of the order that needs to be deleted
 	//       type: integer
+	//       minimum: 1
+	//       format: int64
 	//   required:
 	//     - orderId
 	//

--- a/examples/generated-javascript-project/test/test-plugin.js
+++ b/examples/generated-javascript-project/test/test-plugin.js
@@ -188,6 +188,14 @@ test("testing updatePet", (t) => {
 //     status:
 //       description: Status values that need to be considered for filter
 //       type: array
+//       items:
+//         type: string
+//         enum:
+//           - available
+//           - pending
+//           - sold
+//         default: available
+//       collectionFormat: multi
 //   required:
 //     - status
 //
@@ -280,6 +288,9 @@ test("testing findPetsByStatus", (t) => {
 //     tags:
 //       description: Tags to filter by
 //       type: array
+//       items:
+//         type: string
+//       collectionFormat: multi
 //   required:
 //     - tags
 //
@@ -372,6 +383,7 @@ test("testing findPetsByTags", (t) => {
 //     petId:
 //       description: ID of pet to return
 //       type: integer
+//       format: int64
 //   required:
 //     - petId
 //
@@ -464,6 +476,7 @@ test("testing getPetById", (t) => {
 //     petId:
 //       description: ID of pet that needs to be updated
 //       type: integer
+//       format: int64
 //   required:
 //     - petId
 //
@@ -515,6 +528,7 @@ test("testing updatePetWithForm", (t) => {
 //     petId:
 //       description: Pet id to delete
 //       type: integer
+//       format: int64
 //   required:
 //     - petId
 //
@@ -552,6 +566,7 @@ test("testing deletePet", (t) => {
 //     petId:
 //       description: ID of pet to update
 //       type: integer
+//       format: int64
 //   required:
 //     - petId
 //
@@ -721,6 +736,9 @@ test("testing placeOrder", (t) => {
 //     orderId:
 //       description: ID of pet that needs to be fetched
 //       type: integer
+//       maximum: 10
+//       minimum: 1
+//       format: int64
 //   required:
 //     - orderId
 //
@@ -787,6 +805,8 @@ test("testing getOrderById", (t) => {
 //     orderId:
 //       description: ID of the order that needs to be deleted
 //       type: integer
+//       minimum: 1
+//       format: int64
 //   required:
 //     - orderId
 //

--- a/examples/generated-standaloneJS-project/index.js
+++ b/examples/generated-standaloneJS-project/index.js
@@ -231,6 +231,12 @@ async function generateRoutes(fastify, opts) {
 					status: {
 						description: "Status values that need to be considered for filter",
 						type: "array",
+						items: {
+							type: "string",
+							enum: ["available", "pending", "sold"],
+							default: "available",
+						},
+						collectionFormat: "multi",
 					},
 				},
 				required: ["status"],
@@ -252,6 +258,10 @@ async function generateRoutes(fastify, opts) {
 					tags: {
 						description: "Tags to filter by",
 						type: "array",
+						items: {
+							type: "string",
+						},
+						collectionFormat: "multi",
 					},
 				},
 				required: ["tags"],
@@ -273,6 +283,7 @@ async function generateRoutes(fastify, opts) {
 					petId: {
 						description: "ID of pet to return",
 						type: "integer",
+						format: "int64",
 					},
 				},
 				required: ["petId"],
@@ -307,6 +318,7 @@ async function generateRoutes(fastify, opts) {
 					petId: {
 						description: "ID of pet that needs to be updated",
 						type: "integer",
+						format: "int64",
 					},
 				},
 				required: ["petId"],
@@ -328,6 +340,7 @@ async function generateRoutes(fastify, opts) {
 					petId: {
 						description: "Pet id to delete",
 						type: "integer",
+						format: "int64",
 					},
 				},
 				required: ["petId"],
@@ -362,6 +375,7 @@ async function generateRoutes(fastify, opts) {
 					petId: {
 						description: "ID of pet to update",
 						type: "integer",
+						format: "int64",
 					},
 				},
 				required: ["petId"],
@@ -434,6 +448,9 @@ async function generateRoutes(fastify, opts) {
 					orderId: {
 						description: "ID of pet that needs to be fetched",
 						type: "integer",
+						maximum: 10,
+						minimum: 1,
+						format: "int64",
 					},
 				},
 				required: ["orderId"],
@@ -452,6 +469,8 @@ async function generateRoutes(fastify, opts) {
 					orderId: {
 						description: "ID of the order that needs to be deleted",
 						type: "integer",
+						minimum: 1,
+						format: "int64",
 					},
 				},
 				required: ["orderId"],

--- a/examples/generated-standaloneJS-project/service.js
+++ b/examples/generated-standaloneJS-project/service.js
@@ -148,6 +148,14 @@ export class Service {
 	//     status:
 	//       description: Status values that need to be considered for filter
 	//       type: array
+	//       items:
+	//         type: string
+	//         enum:
+	//           - available
+	//           - pending
+	//           - sold
+	//         default: available
+	//       collectionFormat: multi
 	//   required:
 	//     - status
 	//
@@ -227,6 +235,9 @@ export class Service {
 	//     tags:
 	//       description: Tags to filter by
 	//       type: array
+	//       items:
+	//         type: string
+	//       collectionFormat: multi
 	//   required:
 	//     - tags
 	//
@@ -306,6 +317,7 @@ export class Service {
 	//     petId:
 	//       description: ID of pet to return
 	//       type: integer
+	//       format: int64
 	//   required:
 	//     - petId
 	//
@@ -385,6 +397,7 @@ export class Service {
 	//     petId:
 	//       description: ID of pet that needs to be updated
 	//       type: integer
+	//       format: int64
 	//   required:
 	//     - petId
 	//
@@ -423,6 +436,7 @@ export class Service {
 	//     petId:
 	//       description: Pet id to delete
 	//       type: integer
+	//       format: int64
 	//   required:
 	//     - petId
 	//
@@ -447,6 +461,7 @@ export class Service {
 	//     petId:
 	//       description: ID of pet to update
 	//       type: integer
+	//       format: int64
 	//   required:
 	//     - petId
 	//
@@ -577,6 +592,9 @@ export class Service {
 	//     orderId:
 	//       description: ID of pet that needs to be fetched
 	//       type: integer
+	//       maximum: 10
+	//       minimum: 1
+	//       format: int64
 	//   required:
 	//     - orderId
 	//
@@ -630,6 +648,8 @@ export class Service {
 	//     orderId:
 	//       description: ID of the order that needs to be deleted
 	//       type: integer
+	//       minimum: 1
+	//       format: int64
 	//   required:
 	//     - orderId
 	//

--- a/examples/generated-standaloneJS-project/test/test-plugin.js
+++ b/examples/generated-standaloneJS-project/test/test-plugin.js
@@ -183,6 +183,14 @@ test("testing updatePet", (t) => {
 //     status:
 //       description: Status values that need to be considered for filter
 //       type: array
+//       items:
+//         type: string
+//         enum:
+//           - available
+//           - pending
+//           - sold
+//         default: available
+//       collectionFormat: multi
 //   required:
 //     - status
 //
@@ -275,6 +283,9 @@ test("testing findPetsByStatus", (t) => {
 //     tags:
 //       description: Tags to filter by
 //       type: array
+//       items:
+//         type: string
+//       collectionFormat: multi
 //   required:
 //     - tags
 //
@@ -367,6 +378,7 @@ test("testing findPetsByTags", (t) => {
 //     petId:
 //       description: ID of pet to return
 //       type: integer
+//       format: int64
 //   required:
 //     - petId
 //
@@ -459,6 +471,7 @@ test("testing getPetById", (t) => {
 //     petId:
 //       description: ID of pet that needs to be updated
 //       type: integer
+//       format: int64
 //   required:
 //     - petId
 //
@@ -510,6 +523,7 @@ test("testing updatePetWithForm", (t) => {
 //     petId:
 //       description: Pet id to delete
 //       type: integer
+//       format: int64
 //   required:
 //     - petId
 //
@@ -547,6 +561,7 @@ test("testing deletePet", (t) => {
 //     petId:
 //       description: ID of pet to update
 //       type: integer
+//       format: int64
 //   required:
 //     - petId
 //
@@ -716,6 +731,9 @@ test("testing placeOrder", (t) => {
 //     orderId:
 //       description: ID of pet that needs to be fetched
 //       type: integer
+//       maximum: 10
+//       minimum: 1
+//       format: int64
 //   required:
 //     - orderId
 //
@@ -782,6 +800,8 @@ test("testing getOrderById", (t) => {
 //     orderId:
 //       description: ID of the order that needs to be deleted
 //       type: integer
+//       minimum: 1
+//       format: int64
 //   required:
 //     - orderId
 //

--- a/lib/Parser.v2.js
+++ b/lib/Parser.v2.js
@@ -1,6 +1,28 @@
 // a class for parsing openapi V2 data into config data for fastify
 import { ParserBase } from "./ParserBase.js";
 
+const paramSchemaProps = [
+	"type",
+	"description",
+	"format",
+	"allowEmptyValue",
+	"items",
+	"collectionFormat",
+	"default",
+	"maximum",
+	"exclusiveMaximum",
+	"minimum",
+	"exclusiveMinimum",
+	"maxLength",
+	"minLength",
+	"pattern",
+	"maxItems",
+	"minItems",
+	"uniqueItems",
+	"enum",
+	"multipleOf",
+];
+
 export class ParserV2 extends ParserBase {
 	parseParams(data) {
 		const params = {
@@ -16,10 +38,7 @@ export class ParserV2 extends ParserBase {
 			}
 			//
 			params.properties[item.name] = {};
-			this.copyProps(item, params.properties[item.name], [
-				"type",
-				"description",
-			]);
+			this.copyProps(item, params.properties[item.name], paramSchemaProps);
 			// ajv wants "required" to be an array, which seems to be too strict
 			// see https://github.com/json-schema/json-schema/wiki/Properties-and-required
 			if (item.required) {

--- a/test/test-plugin.v2.js
+++ b/test/test-plugin.v2.js
@@ -349,3 +349,22 @@ test("generic path parameters override works", (t) => {
 		},
 	);
 });
+
+test("schema attributes for non-body parameters work", (t) => {
+	const fastify = Fastify(noStrict);
+	fastify.register(fastifyOpenapiGlue, petStoreOpts);
+	fastify.inject(
+		{
+			method: "GET",
+			url: "v2/store/order/11",
+		},
+		(err, res) => {
+			assert.ifError(err);
+			assert.equal(res.statusCode, 400);
+			const parsedBody = JSON.parse(res.body);
+			assert.equal(parsedBody.statusCode, 400);
+			assert.equal(parsedBody.error, "Bad Request");
+			assert.equal(parsedBody.message, "params/orderId must be <= 10");
+		},
+	);
+});


### PR DESCRIPTION
This fixes #506 and adds the schema fields mentioned there to the V2 parser. 