### PR TITLE
Update dependencies fastify 4.26.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 ## [Unreleased]
 ### Changed
- - update: added a note on using sub schemas to the documentation
+ - update: added a note on using subschemas to the documentation
+ - chore: removed husky as a dependency
+ - updated dependencies
+    - @biomejs/biome                        ^1.5.2  →   ^1.5.3
+    - @seriousme/openapi-schema-validator   ^2.1.5  →   ^2.2.1
+    - fastify                              ^4.25.2  →  ^4.26.1
+    - fastify-cli                           ^6.0.1  →   ^6.1.1
 
 ## [4.4.3] 19-01-2024
 ### Changed

--- a/examples/generated-javascript-project/package.json
+++ b/examples/generated-javascript-project/package.json
@@ -16,13 +16,12 @@
     "@seriousme/openapi-schema-validator": "^2.1.5",
     "js-yaml": "^4.1.0",
     "minimist": "^1.2.8",
-    "fastify-openapi-glue": "^4.4.2"
+    "fastify-openapi-glue": "^4.4.3"
   },
   "devDependencies": {
     "fastify": "^4.25.2",
     "fastify-cli": "^6.0.1",
     "c8": "^9.1.0",
-    "@biomejs/biome": "^1.5.2",
-    "husky": "^8.0.3"
+    "@biomejs/biome": "^1.5.2"
   }
 }

--- a/examples/generated-standaloneJS-project/package.json
+++ b/examples/generated-standaloneJS-project/package.json
@@ -21,7 +21,6 @@
     "fastify": "^4.25.2",
     "fastify-cli": "^6.0.1",
     "c8": "^9.1.0",
-    "@biomejs/biome": "^1.5.2",
-    "husky": "^8.0.3"
+    "@biomejs/biome": "^1.5.2"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,8 +21,7 @@
         "@biomejs/biome": "^1.5.2",
         "c8": "^9.1.0",
         "fastify": "^4.25.2",
-        "fastify-cli": "^6.0.1",
-        "husky": "^9.0.1"
+        "fastify-cli": "^6.0.1"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -1017,21 +1016,6 @@
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
-    },
-    "node_modules/husky": {
-      "version": "9.0.11",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-9.0.11.tgz",
-      "integrity": "sha512-AB6lFlbwwyIqMdHYhwPe+kjOC3Oc5P3nThEoW/AaO2BX3vJDjWPFxYLxokUZOo6RNX20He3AaT8sESs9NJcmEw==",
-      "dev": true,
-      "bin": {
-        "husky": "bin.mjs"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/typicode"
-      }
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
@@ -2855,12 +2839,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
-      "dev": true
-    },
-    "husky": {
-      "version": "9.0.11",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-9.0.11.tgz",
-      "integrity": "sha512-AB6lFlbwwyIqMdHYhwPe+kjOC3Oc5P3nThEoW/AaO2BX3vJDjWPFxYLxokUZOo6RNX20He3AaT8sESs9NJcmEw==",
       "dev": true
     },
     "ieee754": {

--- a/package.json
+++ b/package.json
@@ -18,8 +18,7 @@
     "dev": "fastify start -l info -P examples/petstore/index.js",
     "updateChecksums": "node test/update-checksums.js",
     "preversion": "npm test && git add examples/generated-*-project/package.json",
-    "postversion": "git push && git push --tags",
-    "prepare": "husky install"
+    "postversion": "git push && git push --tags"
   },
   "author": "Hans Klunder",
   "license": "MIT",
@@ -42,8 +41,7 @@
     "@biomejs/biome": "^1.5.2",
     "c8": "^9.1.0",
     "fastify": "^4.25.2",
-    "fastify-cli": "^6.0.1",
-    "husky": "^9.0.1"
+    "fastify-cli": "^6.0.1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
 - chore: removed husky as a dependency
 - updated dependencies
    - @biomejs/biome                        ^1.5.2  →   ^1.5.3
    - @seriousme/openapi-schema-validator   ^2.1.5  →   ^2.2.1
    - fastify                              ^4.25.2  →  ^4.26.1
    - fastify-cli                           ^6.0.1  →   ^6.1.1