### PR TITLE
Feature: x-no-fastify-config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 ### Changed
+
+## [4.5.0] 28-03-2024
+### Changed
+ - feat: add x-no-fastify-config option
  - update: added a note on using subschemas to the documentation
  - chore: removed husky as a dependency
  - updated dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,9 @@
  - update: added a note on using subschemas to the documentation
  - chore: removed husky as a dependency
  - updated dependencies
-    - @biomejs/biome                        ^1.5.2  →   ^1.5.3
+    - @biomejs/biome                        ^1.5.2  →   ^1.6.3
     - @seriousme/openapi-schema-validator   ^2.1.5  →   ^2.2.1
-    - fastify                              ^4.25.2  →  ^4.26.1
+    - fastify                              ^4.25.2  →  ^4.26.2
     - fastify-cli                           ^6.0.1  →   ^6.1.1
 
 ## [4.4.3] 19-01-2024

--- a/README.md
+++ b/README.md
@@ -77,6 +77,19 @@ The following extensions are provided by the plugin:
             description: Webhook processed successfully
   ```
 
+- `x-no-fastify-config` (true): this will ignore this specific route as if it was not present in your OpenAPI specification:
+
+```yaml
+  paths:
+    /webhooks:
+      post:
+        operationId: processWebhook
+        x-no-fastify-config: true
+        responses:
+          204:
+            description: Webhook processed successfully
+  ```
+
 You can also set custom OpenAPI extensions (e.g., `x-myapp-foo`) for use within your app's implementation. These properties are passed through unmodified to the Fastify route on `{req,reply}.routeOptions.config`. Extensions specified on a schema are also accessible (e.g., `routeOptions.schema.body` or `routeOptions.schema.responses[<statusCode>]`).
 
 <a name="generator"></a>

--- a/examples/generated-javascript-project/package.json
+++ b/examples/generated-javascript-project/package.json
@@ -13,15 +13,15 @@
 	},
 	"dependencies": {
 		"fastify-plugin": "^4.5.1",
-		"@seriousme/openapi-schema-validator": "^2.1.5",
+		"@seriousme/openapi-schema-validator": "^2.2.1",
 		"js-yaml": "^4.1.0",
 		"minimist": "^1.2.8",
 		"fastify-openapi-glue": "^4.4.3"
 	},
 	"devDependencies": {
-		"fastify": "^4.25.2",
-		"fastify-cli": "^6.0.1",
+		"fastify": "^4.26.2",
+		"fastify-cli": "^6.1.1",
 		"c8": "^9.1.0",
-		"@biomejs/biome": "^1.5.2"
+		"@biomejs/biome": "^1.6.3"
 	}
 }

--- a/examples/generated-standaloneJS-project/package.json
+++ b/examples/generated-standaloneJS-project/package.json
@@ -13,14 +13,14 @@
 	},
 	"dependencies": {
 		"fastify-plugin": "^4.5.1",
-		"@seriousme/openapi-schema-validator": "^2.1.5",
+		"@seriousme/openapi-schema-validator": "^2.2.1",
 		"js-yaml": "^4.1.0",
 		"minimist": "^1.2.8"
 	},
 	"devDependencies": {
-		"fastify": "^4.25.2",
-		"fastify-cli": "^6.0.1",
+		"fastify": "^4.26.2",
+		"fastify-cli": "^6.1.1",
 		"c8": "^9.1.0",
-		"@biomejs/biome": "^1.5.2"
+		"@biomejs/biome": "^1.6.3"
 	}
 }

--- a/lib/ParserBase.js
+++ b/lib/ParserBase.js
@@ -98,6 +98,9 @@ export class ParserBase {
 	}
 
 	processOperation(path, operation, operationSpec, genericSchema) {
+		if (operationSpec["x-no-fastify-config"]) {
+			return;
+		}
 		const route = {
 			method: operation.toUpperCase(),
 			url: this.makeURL(path),

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "4.4.3",
 			"license": "MIT",
 			"dependencies": {
-				"@seriousme/openapi-schema-validator": "^2.1.5",
+				"@seriousme/openapi-schema-validator": "^2.2.1",
 				"fastify-plugin": "^4.5.1",
 				"js-yaml": "^4.1.0",
 				"minimist": "^1.2.8"
@@ -18,10 +18,10 @@
 				"openapi-glue": "bin/openapi-glue-cli.js"
 			},
 			"devDependencies": {
-				"@biomejs/biome": "^1.5.2",
+				"@biomejs/biome": "^1.6.3",
 				"c8": "^9.1.0",
-				"fastify": "^4.25.2",
-				"fastify-cli": "^6.0.1"
+				"fastify": "^4.26.2",
+				"fastify-cli": "^6.1.1"
 			},
 			"engines": {
 				"node": ">=14.0.0"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
 		"openapi-glue": "./bin/openapi-glue-cli.js"
 	},
 	"dependencies": {
-		"@seriousme/openapi-schema-validator": "^2.1.5",
+		"@seriousme/openapi-schema-validator": "^2.2.1",
 		"fastify-plugin": "^4.5.1",
 		"js-yaml": "^4.1.0",
 		"minimist": "^1.2.8"
@@ -38,10 +38,10 @@
 		"bin": "./bin"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "^1.5.2",
+		"@biomejs/biome": "^1.6.3",
 		"c8": "^9.1.0",
-		"fastify": "^4.25.2",
-		"fastify-cli": "^6.0.1"
+		"fastify": "^4.26.2",
+		"fastify-cli": "^6.1.1"
 	},
 	"repository": {
 		"type": "git",

--- a/test/test-openapi.v3.json
+++ b/test/test-openapi.v3.json
@@ -449,6 +449,18 @@
 					}
 				}
 			}
+		},
+		"/ignoreRoute": {
+			"get": {
+				"operationId": "ignoreRoute",
+				"summary": "Test route correclty being ignored",
+				"x-no-fastify-config": true,
+				"responses": {
+					"200": {
+						"description": "ok"
+					}
+				}
+			}
 		}
 	},
 	"components": {

--- a/test/test-plugin.v3.js
+++ b/test/test-plugin.v3.js
@@ -517,6 +517,29 @@ test("x-fastify-config is applied", (t) => {
 	);
 });
 
+test("x-no-fastify-config is applied", (t) => {
+	const fastify = Fastify();
+	fastify.register(fastifyOpenapiGlue, {
+		...opts,
+		serviceHandlers: {
+			ignoreRoute: (req, reply) => {
+				return reply;
+			},
+		},
+	});
+
+	fastify.inject(
+		{
+			method: "GET",
+			url: "/ignoreRoute",
+		},
+		(err, res) => {
+			assert.ifError(err);
+			assert.equal(res.statusCode, 404);
+		},
+	);
+});
+
 test("service and operationResolver together throw error", (t) => {
 	const fastify = Fastify();
 	fastify.register(fastifyOpenapiGlue, serviceAndOperationResolver);


### PR DESCRIPTION
This feature adds the option to ignore a  route in an OpenApi specification, see README.md for details.