### PR TITLE
chore: Updated dependencies Biome 1.9.4 etc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 ## [Unreleased]
 ### Changed
 
+## [4.7.2] 12-11-2024
+### Changed
+- chore: updated dependencies
+   - @biomejs/biome                       ^1.9.0  →  ^1.9.4
+   - @seriousme/openapi-schema-validator  ^2.2.3  →  ^2.2.4
+   - fastify                              ^5.0.0  →  ^5.1.0
+   - fastify-cli                          ^7.0.0  →  ^7.0.1
+   - fastify-plugin                       ^5.0.0  →  ^5.0.1
+
 ## [4.7.1] 12-09-2024
 ### Changed
 - fix: support "content" field for query string

--- a/examples/generated-javascript-project/package.json
+++ b/examples/generated-javascript-project/package.json
@@ -12,16 +12,16 @@
     "test": "test"
   },
   "dependencies": {
-    "fastify-plugin": "^5.0.0",
-    "@seriousme/openapi-schema-validator": "^2.2.3",
+    "fastify-plugin": "^5.0.1",
+    "@seriousme/openapi-schema-validator": "^2.2.4",
     "js-yaml": "^4.1.0",
     "minimist": "^1.2.8",
     "fastify-openapi-glue": "^4.7.1"
   },
   "devDependencies": {
-    "fastify": "^5.0.0",
-    "fastify-cli": "^7.0.0",
+    "fastify": "^5.1.0",
+    "fastify-cli": "^7.0.1",
     "c8": "^10.1.2",
-    "@biomejs/biome": "^1.9.0"
+    "@biomejs/biome": "^1.9.4"
   }
 }

--- a/examples/generated-standaloneJS-project/package.json
+++ b/examples/generated-standaloneJS-project/package.json
@@ -12,15 +12,15 @@
     "test": "test"
   },
   "dependencies": {
-    "fastify-plugin": "^5.0.0",
-    "@seriousme/openapi-schema-validator": "^2.2.3",
+    "fastify-plugin": "^5.0.1",
+    "@seriousme/openapi-schema-validator": "^2.2.4",
     "js-yaml": "^4.1.0",
     "minimist": "^1.2.8"
   },
   "devDependencies": {
-    "fastify": "^5.0.0",
-    "fastify-cli": "^7.0.0",
+    "fastify": "^5.1.0",
+    "fastify-cli": "^7.0.1",
     "c8": "^10.1.2",
-    "@biomejs/biome": "^1.9.0"
+    "@biomejs/biome": "^1.9.4"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
 			"version": "4.7.1",
 			"license": "MIT",
 			"dependencies": {
-				"@seriousme/openapi-schema-validator": "^2.2.3",
-				"fastify-plugin": "^5.0.0",
+				"@seriousme/openapi-schema-validator": "^2.2.4",
+				"fastify-plugin": "^5.0.1",
 				"js-yaml": "^4.1.0",
 				"minimist": "^1.2.8"
 			},
@@ -18,10 +18,10 @@
 				"openapi-glue": "bin/openapi-glue-cli.js"
 			},
 			"devDependencies": {
-				"@biomejs/biome": "^1.9.0",
+				"@biomejs/biome": "^1.9.4",
 				"c8": "^10.1.2",
-				"fastify": "^5.0.0",
-				"fastify-cli": "^7.0.0"
+				"fastify": "^5.1.0",
+				"fastify-cli": "^7.0.1"
 			},
 			"engines": {
 				"node": ">=14.0.0"
@@ -364,9 +364,10 @@
 			}
 		},
 		"node_modules/@seriousme/openapi-schema-validator": {
-			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/@seriousme/openapi-schema-validator/-/openapi-schema-validator-2.2.3.tgz",
-			"integrity": "sha512-tIb0lRK5khbs2yuWfUIN/5dmlx04wYcUMQ6OxPK2H4k/ml5j5Fra9zZjhYVP5nO/bx20BgZbsjrCVEAWb+xBIQ==",
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/@seriousme/openapi-schema-validator/-/openapi-schema-validator-2.2.4.tgz",
+			"integrity": "sha512-kjFZbn3tbRkORGzxzpL1ZjxNn/a0uS9RIfVEy48KP1K+IGdnuxIWn40v/ITVu9a51NlSQixdFRIZOxyhEp0Z5A==",
+			"license": "MIT",
 			"dependencies": {
 				"ajv": "^8.17.1",
 				"ajv-draft-04": "^1.0.0",
@@ -2344,9 +2345,9 @@
 			"optional": true
 		},
 		"@seriousme/openapi-schema-validator": {
-			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/@seriousme/openapi-schema-validator/-/openapi-schema-validator-2.2.3.tgz",
-			"integrity": "sha512-tIb0lRK5khbs2yuWfUIN/5dmlx04wYcUMQ6OxPK2H4k/ml5j5Fra9zZjhYVP5nO/bx20BgZbsjrCVEAWb+xBIQ==",
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/@seriousme/openapi-schema-validator/-/openapi-schema-validator-2.2.4.tgz",
+			"integrity": "sha512-kjFZbn3tbRkORGzxzpL1ZjxNn/a0uS9RIfVEy48KP1K+IGdnuxIWn40v/ITVu9a51NlSQixdFRIZOxyhEp0Z5A==",
 			"requires": {
 				"ajv": "^8.17.1",
 				"ajv-draft-04": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
 		"openapi-glue": "./bin/openapi-glue-cli.js"
 	},
 	"dependencies": {
-		"@seriousme/openapi-schema-validator": "^2.2.3",
-		"fastify-plugin": "^5.0.0",
+		"@seriousme/openapi-schema-validator": "^2.2.4",
+		"fastify-plugin": "^5.0.1",
 		"js-yaml": "^4.1.0",
 		"minimist": "^1.2.8"
 	},
@@ -38,10 +38,10 @@
 		"bin": "./bin"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "^1.9.0",
+		"@biomejs/biome": "^1.9.4",
 		"c8": "^10.1.2",
-		"fastify": "^5.0.0",
-		"fastify-cli": "^7.0.0"
+		"fastify": "^5.1.0",
+		"fastify-cli": "^7.0.1"
 	},
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
### Changed
- chore: updated dependencies
   - @biomejs/biome                       ^1.9.0  →  ^1.9.4
   - @seriousme/openapi-schema-validator  ^2.2.3  →  ^2.2.4
   - fastify                              ^5.0.0  →  ^5.1.0
   - fastify-cli                          ^7.0.0  →  ^7.0.1
   - fastify-plugin                       ^5.0.0  →  ^5.0.1