### PR TITLE
Update @seriousme/openapi-schema-validator to 2.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## [Unreleased]
 ### Changed
 
+## [4.7.3] 14-11-2024
+### Changed
+- chore: updated dependencies
+   - @seriousme/openapi-schema-validator  ^2.2.4  →  ^2.2.5
+
 ## [4.7.2] 12-11-2024
 ### Changed
 - chore: updated dependencies

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "4.7.2",
 			"license": "MIT",
 			"dependencies": {
-				"@seriousme/openapi-schema-validator": "^2.2.4",
+				"@seriousme/openapi-schema-validator": "^2.2.5",
 				"fastify-plugin": "^5.0.1",
 				"js-yaml": "^4.1.0",
 				"minimist": "^1.2.8"
@@ -364,9 +364,9 @@
 			}
 		},
 		"node_modules/@seriousme/openapi-schema-validator": {
-			"version": "2.2.4",
-			"resolved": "https://registry.npmjs.org/@seriousme/openapi-schema-validator/-/openapi-schema-validator-2.2.4.tgz",
-			"integrity": "sha512-kjFZbn3tbRkORGzxzpL1ZjxNn/a0uS9RIfVEy48KP1K+IGdnuxIWn40v/ITVu9a51NlSQixdFRIZOxyhEp0Z5A==",
+			"version": "2.2.5",
+			"resolved": "https://registry.npmjs.org/@seriousme/openapi-schema-validator/-/openapi-schema-validator-2.2.5.tgz",
+			"integrity": "sha512-WQJjr03X6PLw8TOC4vTHqPl9ihtpY17jaVBJ6Yt/lHrGabUYP+BTq4yM9AbfDLP5C7v6+sfF2OJsET/W7QvKQw==",
 			"license": "MIT",
 			"dependencies": {
 				"ajv": "^8.17.1",
@@ -2345,9 +2345,9 @@
 			"optional": true
 		},
 		"@seriousme/openapi-schema-validator": {
-			"version": "2.2.4",
-			"resolved": "https://registry.npmjs.org/@seriousme/openapi-schema-validator/-/openapi-schema-validator-2.2.4.tgz",
-			"integrity": "sha512-kjFZbn3tbRkORGzxzpL1ZjxNn/a0uS9RIfVEy48KP1K+IGdnuxIWn40v/ITVu9a51NlSQixdFRIZOxyhEp0Z5A==",
+			"version": "2.2.5",
+			"resolved": "https://registry.npmjs.org/@seriousme/openapi-schema-validator/-/openapi-schema-validator-2.2.5.tgz",
+			"integrity": "sha512-WQJjr03X6PLw8TOC4vTHqPl9ihtpY17jaVBJ6Yt/lHrGabUYP+BTq4yM9AbfDLP5C7v6+sfF2OJsET/W7QvKQw==",
 			"requires": {
 				"ajv": "^8.17.1",
 				"ajv-draft-04": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
 		"openapi-glue": "./bin/openapi-glue-cli.js"
 	},
 	"dependencies": {
-		"@seriousme/openapi-schema-validator": "^2.2.4",
+		"@seriousme/openapi-schema-validator": "^2.2.5",
 		"fastify-plugin": "^5.0.1",
 		"js-yaml": "^4.1.0",
 		"minimist": "^1.2.8"


### PR DESCRIPTION
### Changed
- chore: updated dependencies
   - @seriousme/openapi-schema-validator  ^2.2.4  →  ^2.2.5