### PR TITLE
Add await to deterministically finish registering with fastify

### DIFF
--- a/examples/generated-javascript-project/package.json
+++ b/examples/generated-javascript-project/package.json
@@ -16,7 +16,7 @@
     "@seriousme/openapi-schema-validator": "^2.2.5",
     "js-yaml": "^4.1.0",
     "minimist": "^1.2.8",
-    "fastify-openapi-glue": "^4.7.2"
+    "fastify-openapi-glue": "^4.7.3"
   },
   "devDependencies": {
     "fastify": "^5.1.0",

--- a/index.js
+++ b/index.js
@@ -149,7 +149,10 @@ async function plugin(instance, opts) {
 		routeConf.prefix = config.prefix;
 	}
 
-	instance.register(makeGenerateRoutes(config, resolver, security), routeConf);
+	await instance.register(
+		makeGenerateRoutes(config, resolver, security),
+		routeConf,
+	);
 }
 
 const fastifyOpenapiGlue = fp(plugin, {


### PR DESCRIPTION
Closes #627

Impact to users should be negligeble. If they weren't awaiting their own `fastify.register` call, then there is no behavior difference. If they are awaiting their `fastify.register` call, they were probably expecting the routes to be loaded and ready right after.

Alternative solution, branch the code and only perform the await based on some new opt-in option.

Should I look at impact to this projects tests?