### PR TITLE
Update openapi-schema-validator to 2.3.0

### DIFF
--- a/examples/generated-javascript-project/package.json
+++ b/examples/generated-javascript-project/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "fastify-plugin": "^5.0.1",
-    "@seriousme/openapi-schema-validator": "^2.2.5",
+    "@seriousme/openapi-schema-validator": "^2.3.0",
     "js-yaml": "^4.1.0",
     "minimist": "^1.2.8",
     "fastify-openapi-glue": "^4.7.3"

--- a/examples/generated-standaloneJS-project/package.json
+++ b/examples/generated-standaloneJS-project/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "fastify-plugin": "^5.0.1",
-    "@seriousme/openapi-schema-validator": "^2.2.5",
+    "@seriousme/openapi-schema-validator": "^2.3.0",
     "js-yaml": "^4.1.0",
     "minimist": "^1.2.8"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "4.7.3",
 			"license": "MIT",
 			"dependencies": {
-				"@seriousme/openapi-schema-validator": "^2.2.5",
+				"@seriousme/openapi-schema-validator": "^2.3.0",
 				"fastify-plugin": "^5.0.1",
 				"js-yaml": "^4.1.0",
 				"minimist": "^1.2.8"
@@ -670,10 +670,11 @@
 			}
 		},
 		"node_modules/cross-spawn": {
-			"version": "7.0.3",
-			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-			"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+			"integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"path-key": "^3.1.0",
 				"shebang-command": "^2.0.0",
@@ -2552,9 +2553,9 @@
 			"dev": true
 		},
 		"cross-spawn": {
-			"version": "7.0.3",
-			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-			"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+			"integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
 			"dev": true,
 			"requires": {
 				"path-key": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
 		"openapi-glue": "./bin/openapi-glue-cli.js"
 	},
 	"dependencies": {
-		"@seriousme/openapi-schema-validator": "^2.2.5",
+		"@seriousme/openapi-schema-validator": "^2.3.0",
 		"fastify-plugin": "^5.0.1",
 		"js-yaml": "^4.1.0",
 		"minimist": "^1.2.8"


### PR DESCRIPTION
### Changed
- chore: updated dependencies
   - @seriousme/openapi-schema-validator  ^2.2.5  →  ^2.3.0
