### PR TITLE
chore: replace minimist by node:util.parseArgs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,15 @@
 
 ## [Unreleased]
 ### Changed
+
+## [4.9.1] 27-04-2025
+### Changed
 - doc: added note on using schema 2020
+- chore: updated dependencies
+   -  @seriousme/openapi-schema-validator  ^2.4.0  →  ^2.4.1
+   -  fastify                              ^5.2.2  →  ^5.3.2
+   -  fastify-cli                          ^7.3.0  →  ^7.4.0
+   -  minimist replaced by node:util.parseArgs
 
 ## [4.9.0] 28-03-2025
 ### Changed

--- a/bin/openapi-glue-cli.js
+++ b/bin/openapi-glue-cli.js
@@ -3,7 +3,7 @@
 import { basename, resolve } from "node:path";
 import { exit } from "node:process";
 import { fileURLToPath } from "node:url";
-import argvParser from "minimist";
+import { parseArgs } from "node:util";
 import { Generator } from "../lib/generator.js";
 const __filename = fileURLToPath(import.meta.url);
 
@@ -20,7 +20,7 @@ Any existing files in the project folder will be overwritten!
 Options:
 
   -p <name>                   The name of the project to generate
-  --projectName=<name>        [default: ${argvOptions.default.projectName}]
+  --projectName=<name>        [default: ${process.cwd()}]
                               
   -b <dir> --baseDir=<dir>    Directory to generate the project in.
                               This directory must already exist.
@@ -33,33 +33,45 @@ Options:
  The following options are only usefull for testing the openapi-glue plugin:
   -c --checksumOnly           Don't generate the project on disk but
                               return checksums only. 
-  -l --localPlugin            Use a local path to the plugin. 
+  -l --localPlugin           Use a local path to the plugin. 
                         
 `);
 	exit(1);
 }
 
-const argvOptions = {
-	string: ["baseDir", "projectName", "type", "_"],
-	boolean: ["checksumOnly", "localPlugin"],
-	alias: {
-		baseDir: "b",
-		projectName: "p",
-		checksumOnly: "c",
-		localPlugin: "l",
-		type: "t",
+const options = {
+	baseDir: {
+		type: "string",
+		short: "b",
+		default: process.cwd(),
 	},
-
-	default: {
-		baseDir: process.cwd(),
-		checksumOnly: false,
-		localPlugin: false,
-		type: "javascript",
+	projectName: {
+		type: "string",
+		short: "p",
+	},
+	type: {
+		type: "string",
+		short: "t",
+		default: "javascript",
+	},
+	checksumOnly: {
+		type: "boolean",
+		short: "c",
+		default: false,
+	},
+	localPlugin: {
+		type: "boolean",
+		short: "l",
+		default: false,
 	},
 };
 
-const argv = argvParser(process.argv.slice(2), argvOptions);
-argv.specification = argv._.shift();
+const { values: argv, positionals } = parseArgs({
+	options,
+	allowPositionals: true,
+});
+
+argv.specification = positionals[0];
 
 if (!argv.specification) {
 	usage();

--- a/examples/generated-javascript-project/package.json
+++ b/examples/generated-javascript-project/package.json
@@ -13,14 +13,13 @@
   },
   "dependencies": {
     "fastify-plugin": "^5.0.1",
-    "@seriousme/openapi-schema-validator": "^2.4.0",
+    "@seriousme/openapi-schema-validator": "^2.4.1",
     "js-yaml": "^4.1.0",
-    "minimist": "^1.2.8",
-    "fastify-openapi-glue": "^4.8.1"
+    "fastify-openapi-glue": "^4.9.0"
   },
   "devDependencies": {
-    "fastify": "^5.2.2",
-    "fastify-cli": "^7.3.0",
+    "fastify": "^5.3.2",
+    "fastify-cli": "^7.4.0",
     "c8": "^10.1.3",
     "@biomejs/biome": "^1.9.4"
   }

--- a/examples/generated-standaloneJS-project/package.json
+++ b/examples/generated-standaloneJS-project/package.json
@@ -13,13 +13,12 @@
   },
   "dependencies": {
     "fastify-plugin": "^5.0.1",
-    "@seriousme/openapi-schema-validator": "^2.4.0",
-    "js-yaml": "^4.1.0",
-    "minimist": "^1.2.8"
+    "@seriousme/openapi-schema-validator": "^2.4.1",
+    "js-yaml": "^4.1.0"
   },
   "devDependencies": {
-    "fastify": "^5.2.2",
-    "fastify-cli": "^7.3.0",
+    "fastify": "^5.3.2",
+    "fastify-cli": "^7.4.0",
     "c8": "^10.1.3",
     "@biomejs/biome": "^1.9.4"
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,9 @@
 			"version": "4.9.0",
 			"license": "MIT",
 			"dependencies": {
-				"@seriousme/openapi-schema-validator": "^2.4.0",
+				"@seriousme/openapi-schema-validator": "^2.4.1",
 				"fastify-plugin": "^5.0.1",
-				"js-yaml": "^4.1.0",
-				"minimist": "^1.2.8"
+				"js-yaml": "^4.1.0"
 			},
 			"bin": {
 				"openapi-glue": "bin/openapi-glue-cli.js"
@@ -20,8 +19,8 @@
 			"devDependencies": {
 				"@biomejs/biome": "^1.9.4",
 				"c8": "^10.1.3",
-				"fastify": "^5.2.2",
-				"fastify-cli": "^7.3.0"
+				"fastify": "^5.3.2",
+				"fastify-cli": "^7.4.0"
 			},
 			"engines": {
 				"node": ">=14.0.0"
@@ -383,16 +382,15 @@
 			}
 		},
 		"node_modules/@seriousme/openapi-schema-validator": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/@seriousme/openapi-schema-validator/-/openapi-schema-validator-2.4.0.tgz",
-			"integrity": "sha512-2PWq2QbDMu+CANpBLZ2Uch9PgTIiftLpiLH4lcaykjV463f4Vt9eD61EeaVI++D0HII4JKnptX46391pII1XZA==",
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/@seriousme/openapi-schema-validator/-/openapi-schema-validator-2.4.1.tgz",
+			"integrity": "sha512-OX15CKLV2JFGcoXxFVD/CMtWzys+r6G9gArKY8iaUqOkIEqp80ispclk5c8j5i1iEIIlyCRJ0R0N5MddHFg2xg==",
 			"license": "MIT",
 			"dependencies": {
 				"ajv": "^8.17.1",
 				"ajv-draft-04": "^1.0.0",
 				"ajv-formats": "^3.0.1",
-				"js-yaml": "^4.1.0",
-				"minimist": "^1.2.8"
+				"js-yaml": "^4.1.0"
 			},
 			"bin": {
 				"bundle-api": "bin/bundle-api-cli.js",
@@ -842,9 +840,9 @@
 			"integrity": "sha512-MWipKbbYiYI0UC7cl8m/i/IWTqfC8YXsqjzybjddLsFjStroQzsHXkc73JutMvBiXmOvapk+axIl79ig5t55Bw=="
 		},
 		"node_modules/fastify": {
-			"version": "5.3.1",
-			"resolved": "https://registry.npmjs.org/fastify/-/fastify-5.3.1.tgz",
-			"integrity": "sha512-PhpFhuUZVnq1IvTHCrIMCqqukNuJGWnV/nxTrSDtirbsAZnVYO8I9LaxSk5OPXSiioA6DoEG1r5U1g41/cix0g==",
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/fastify/-/fastify-5.3.2.tgz",
+			"integrity": "sha512-AIPqBgtqBAwkOkrnwesEE+dOyU30dQ4kh7udxeGVR05CRGwubZx+p2H8P0C4cRnQT0+EPK4VGea2DTL2RtWttg==",
 			"dev": true,
 			"funding": [
 				{
@@ -1269,6 +1267,7 @@
 			"version": "1.2.8",
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
 			"integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+			"dev": true,
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
@@ -2349,15 +2348,14 @@
 			"optional": true
 		},
 		"@seriousme/openapi-schema-validator": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/@seriousme/openapi-schema-validator/-/openapi-schema-validator-2.4.0.tgz",
-			"integrity": "sha512-2PWq2QbDMu+CANpBLZ2Uch9PgTIiftLpiLH4lcaykjV463f4Vt9eD61EeaVI++D0HII4JKnptX46391pII1XZA==",
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/@seriousme/openapi-schema-validator/-/openapi-schema-validator-2.4.1.tgz",
+			"integrity": "sha512-OX15CKLV2JFGcoXxFVD/CMtWzys+r6G9gArKY8iaUqOkIEqp80ispclk5c8j5i1iEIIlyCRJ0R0N5MddHFg2xg==",
 			"requires": {
 				"ajv": "^8.17.1",
 				"ajv-draft-04": "^1.0.0",
 				"ajv-formats": "^3.0.1",
-				"js-yaml": "^4.1.0",
-				"minimist": "^1.2.8"
+				"js-yaml": "^4.1.0"
 			}
 		},
 		"@types/istanbul-lib-coverage": {
@@ -2685,9 +2683,9 @@
 			"integrity": "sha512-MWipKbbYiYI0UC7cl8m/i/IWTqfC8YXsqjzybjddLsFjStroQzsHXkc73JutMvBiXmOvapk+axIl79ig5t55Bw=="
 		},
 		"fastify": {
-			"version": "5.3.1",
-			"resolved": "https://registry.npmjs.org/fastify/-/fastify-5.3.1.tgz",
-			"integrity": "sha512-PhpFhuUZVnq1IvTHCrIMCqqukNuJGWnV/nxTrSDtirbsAZnVYO8I9LaxSk5OPXSiioA6DoEG1r5U1g41/cix0g==",
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/fastify/-/fastify-5.3.2.tgz",
+			"integrity": "sha512-AIPqBgtqBAwkOkrnwesEE+dOyU30dQ4kh7udxeGVR05CRGwubZx+p2H8P0C4cRnQT0+EPK4VGea2DTL2RtWttg==",
 			"dev": true,
 			"requires": {
 				"@fastify/ajv-compiler": "^4.0.0",
@@ -2984,7 +2982,8 @@
 		"minimist": {
 			"version": "1.2.8",
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-			"integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="
+			"integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+			"dev": true
 		},
 		"minipass": {
 			"version": "7.1.2",

--- a/package.json
+++ b/package.json
@@ -26,10 +26,9 @@
 		"openapi-glue": "./bin/openapi-glue-cli.js"
 	},
 	"dependencies": {
-		"@seriousme/openapi-schema-validator": "^2.4.0",
+		"@seriousme/openapi-schema-validator": "^2.4.1",
 		"fastify-plugin": "^5.0.1",
-		"js-yaml": "^4.1.0",
-		"minimist": "^1.2.8"
+		"js-yaml": "^4.1.0"
 	},
 	"directories": {
 		"example": "./examples",
@@ -40,8 +39,8 @@
 	"devDependencies": {
 		"@biomejs/biome": "^1.9.4",
 		"c8": "^10.1.3",
-		"fastify": "^5.2.2",
-		"fastify-cli": "^7.3.0"
+		"fastify": "^5.3.2",
+		"fastify-cli": "^7.4.0"
 	},
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
### Changed
- doc: added note on using schema 2020
- chore: updated dependencies
   -  @seriousme/openapi-schema-validator  ^2.4.0  →  ^2.4.1
   -  fastify                              ^5.2.2  →  ^5.3.2
   -  fastify-cli                          ^7.3.0  →  ^7.4.0
   -  minimist replaced by node:util.parseArgs
