### PR TITLE
feat: add support for OpenApi 3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 ## [Unreleased]
 ### Changed
 
+## [4.10.0] 26-09-2025
+### Changed
+- feat: add support for OpenApi 3.2
+- chore: updated dependencies
+   - @seriousme/openapi-schema-validator  ^2.4.4  →  ^2.7.0
+   - @biomejs/biome  ^2.2.0  →  ^2.2.4
+   - fastify         ^5.5.0  →  ^5.6.1
+
 ## [4.9.2] 17-08-2025
 ### Changed
 - feat(dev): add index.d.ts tests

--- a/docs/schema2020.md
+++ b/docs/schema2020.md
@@ -9,7 +9,7 @@ At the time of writing (April 2025) AJV uses [JSON schema draft-07 as default ve
 
 The OpenApi specifications until 3.1 (e.g. [3.0.4](https://spec.openapis.org/oas/v3.0.4.html#schema-object)) specify JSON schema draft-05, this works fine with AJV's draft-07.
 
-The OpenApi specifications from 3.1 (e.g. [3.1.0](https://spec.openapis.org/oas/v3.1.0.html#schema-object)) specify JSON schema draft-2020-12 which works fine with AJV's draft-07 most of the time but has some new additions like `unevaluatedProperties` and even some breaking changes, see https://ajv.js.org/json-schema.html#json-schema-versions.
+The OpenApi specifications from 3.1 (e.g. [3.2.0](https://spec.openapis.org/oas/v3.2.0.html#schema-object)) specify JSON schema draft-2020-12 which works fine with AJV's draft-07 most of the time but has some new additions like `unevaluatedProperties` and even some breaking changes, see https://ajv.js.org/json-schema.html#json-schema-versions.
 
 If you have/need these new additions in your OpenApi specification you need to tell `Fastify` to use `AJV` with `2020` schema.
 

--- a/examples/generated-javascript-project/package.json
+++ b/examples/generated-javascript-project/package.json
@@ -15,7 +15,7 @@
     "fastify-plugin": "^5.0.1",
     "@seriousme/openapi-schema-validator": "^2.4.4",
     "js-yaml": "^4.1.0",
-    "fastify-openapi-glue": "^4.9.1"
+    "fastify-openapi-glue": "^4.9.2"
   },
   "devDependencies": {
     "fastify": "^5.5.0",

--- a/examples/generated-javascript-project/package.json
+++ b/examples/generated-javascript-project/package.json
@@ -13,15 +13,15 @@
   },
   "dependencies": {
     "fastify-plugin": "^5.0.1",
-    "@seriousme/openapi-schema-validator": "^2.4.4",
+    "@seriousme/openapi-schema-validator": "^2.7.0",
     "js-yaml": "^4.1.0",
     "fastify-openapi-glue": "^4.9.2"
   },
   "devDependencies": {
-    "fastify": "^5.5.0",
+    "fastify": "^5.6.1",
     "fastify-cli": "^7.4.0",
     "c8": "^10.1.3",
-    "@biomejs/biome": "^2.2.0",
+    "@biomejs/biome": "^2.2.4",
     "expect-type": "^1.2.2",
     "typescript": "^5.9.2"
   }

--- a/examples/generated-standaloneJS-project/package.json
+++ b/examples/generated-standaloneJS-project/package.json
@@ -13,14 +13,14 @@
   },
   "dependencies": {
     "fastify-plugin": "^5.0.1",
-    "@seriousme/openapi-schema-validator": "^2.4.4",
+    "@seriousme/openapi-schema-validator": "^2.7.0",
     "js-yaml": "^4.1.0"
   },
   "devDependencies": {
-    "fastify": "^5.5.0",
+    "fastify": "^5.6.1",
     "fastify-cli": "^7.4.0",
     "c8": "^10.1.3",
-    "@biomejs/biome": "^2.2.0",
+    "@biomejs/biome": "^2.2.4",
     "expect-type": "^1.2.2",
     "typescript": "^5.9.2"
   }

--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -42,12 +42,12 @@ export class Parser {
 	 */
 
 	async parse(specification, options = {}) {
-		const supportedVersions = new Set(["2.0", "3.0", "3.1"]);
+		const supportedVersions = new Set(["2.0", "3.0", "3.1", "3.2"]);
 
 		const res = await this.preProcessSpec(specification);
 		if (!(res.valid && supportedVersions.has(res.version))) {
 			throw new Error(
-				"'specification' parameter must contain a valid version 2.0 or 3.0.x or 3.1.x specification",
+				"'specification' parameter must contain a valid specification of a supported OpenApi version",
 			);
 		}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "4.9.2",
 			"license": "MIT",
 			"dependencies": {
-				"@seriousme/openapi-schema-validator": "^2.4.4",
+				"@seriousme/openapi-schema-validator": "^2.7.0",
 				"fastify-plugin": "^5.0.1",
 				"js-yaml": "^4.1.0"
 			},
@@ -383,9 +383,10 @@
 			}
 		},
 		"node_modules/@seriousme/openapi-schema-validator": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@seriousme/openapi-schema-validator/-/openapi-schema-validator-2.6.0.tgz",
-			"integrity": "sha512-LCjWH2owSa7jSuvieS0OxszSjsZ5CMBWQWVbSYlmoQiJ8ya7cvDnSvhmhWxdDeNzVIYa77uCW3d6RIg5YOrmZA==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/@seriousme/openapi-schema-validator/-/openapi-schema-validator-2.7.0.tgz",
+			"integrity": "sha512-7GrE9T3UWTWpIyaUq+r+UlsaMJhHFhzGtXkjBMZDIo5Pz+iNDT3oBt0N/EdGX7HDRt5TDmdIJGR8co3O/qOvWw==",
+			"license": "MIT",
 			"dependencies": {
 				"ajv": "^8.17.1",
 				"ajv-draft-04": "^1.0.0",
@@ -2372,9 +2373,9 @@
 			"optional": true
 		},
 		"@seriousme/openapi-schema-validator": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@seriousme/openapi-schema-validator/-/openapi-schema-validator-2.6.0.tgz",
-			"integrity": "sha512-LCjWH2owSa7jSuvieS0OxszSjsZ5CMBWQWVbSYlmoQiJ8ya7cvDnSvhmhWxdDeNzVIYa77uCW3d6RIg5YOrmZA==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/@seriousme/openapi-schema-validator/-/openapi-schema-validator-2.7.0.tgz",
+			"integrity": "sha512-7GrE9T3UWTWpIyaUq+r+UlsaMJhHFhzGtXkjBMZDIo5Pz+iNDT3oBt0N/EdGX7HDRt5TDmdIJGR8co3O/qOvWw==",
 			"requires": {
 				"ajv": "^8.17.1",
 				"ajv-draft-04": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,10 +17,10 @@
 				"openapi-glue": "bin/openapi-glue-cli.js"
 			},
 			"devDependencies": {
-				"@biomejs/biome": "^2.2.0",
+				"@biomejs/biome": "^2.2.4",
 				"c8": "^10.1.3",
 				"expect-type": "^1.2.2",
-				"fastify": "^5.5.0",
+				"fastify": "^5.6.1",
 				"fastify-cli": "^7.4.0",
 				"typescript": "^5.9.2"
 			},

--- a/package.json
+++ b/package.json
@@ -39,10 +39,10 @@
 		"bin": "./bin"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "^2.2.0",
+		"@biomejs/biome": "^2.2.4",
 		"c8": "^10.1.3",
 		"expect-type": "^1.2.2",
-		"fastify": "^5.5.0",
+		"fastify": "^5.6.1",
 		"fastify-cli": "^7.4.0",
 		"typescript": "^5.9.2"
 	},

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
 		"openapi-glue": "./bin/openapi-glue-cli.js"
 	},
 	"dependencies": {
-		"@seriousme/openapi-schema-validator": "^2.4.4",
+		"@seriousme/openapi-schema-validator": "^2.7.0",
 		"fastify-plugin": "^5.0.1",
 		"js-yaml": "^4.1.0"
 	},

--- a/test/test-plugin.v2.js
+++ b/test/test-plugin.v2.js
@@ -171,7 +171,7 @@ test("invalid openapi v2 specification throws error ", (t, done) => {
 		if (err) {
 			t.assert.equal(
 				err.message,
-				"'specification' parameter must contain a valid version 2.0 or 3.0.x or 3.1.x specification",
+				"'specification' parameter must contain a valid specification of a supported OpenApi version",
 				"got expected error",
 			);
 			done();

--- a/test/test-plugin.v3.js
+++ b/test/test-plugin.v3.js
@@ -288,7 +288,7 @@ test("invalid openapi v3 specification throws error ", (t, done) => {
 		if (err) {
 			t.assert.equal(
 				err.message,
-				"'specification' parameter must contain a valid version 2.0 or 3.0.x or 3.1.x specification",
+				"'specification' parameter must contain a valid specification of a supported OpenApi version",
 				"got expected error",
 			);
 			done();


### PR DESCRIPTION
### Changed
- feat: add support for OpenApi 3.2
- chore: updated dependencies
   - @seriousme/openapi-schema-validator  ^2.4.4  →  ^2.7.0
   - @biomejs/biome  ^2.2.0  →  ^2.2.4
   - fastify         ^5.5.0  →  ^5.6.1