### PR TITLE
fix:  do not mutate specification parameter

### DIFF
--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -15,9 +15,10 @@ export class Parser {
 	async preProcessSpec(specification) {
 		const validator = new Validator();
 		try {
-			const res = await validator.validate(specification);
+			// clone the original specification as resolveRefs modifies the schema
+			const spec = JSON.parse(JSON.stringify(specification, null, 2));
+			const res = await validator.validate(spec);
 			if (res.valid) {
-				// clone the original specification as resolveRefs modifies the schema
 				this.original = JSON.parse(
 					JSON.stringify(validator.specification, null, 2),
 				);

--- a/test/service.js
+++ b/test/service.js
@@ -167,6 +167,62 @@ export class Service {
 		return "";
 	}
 
+	// Operation: postRecursive
+	// URL: /recursive
+	// summary:	Test recursive parameters
+	// req.body
+	//   content:
+	//     application/json:
+	//       schema:
+	//         type: object
+	//         additionalProperties: false
+	//         properties:
+	//           str1:
+	//             type: string
+	//           arr:
+	//             type: array
+	//             items: &a1
+	//               type: string
+	//           objRef:
+	//             $ref: "#"
+	//           arrRef:
+	//             type: array
+	//             items:
+	//               $ref: "#"
+	//           refStr: *a1
+	//         $id: http://example.com/fastifySchema
+	//
+	// valid responses
+	//   "200":
+	//     description: ok
+	//     content:
+	//       application/json:
+	//         schema:
+	//           type: object
+	//           additionalProperties: false
+	//           properties:
+	//             str1:
+	//               type: string
+	//             arr:
+	//               type: array
+	//               items: &a1
+	//                 type: string
+	//             objRef:
+	//               $ref: "#"
+	//             arrRef:
+	//               type: array
+	//               items:
+	//                 $ref: "#"
+	//             refStr: *a1
+	//           required:
+	//             - str1
+	//           $id: http://example.com/fastifySchema
+	//
+
+	async postRecursive(req) {
+		return req.body;
+	}
+
 	// Operation: getResponse
 	// summary:  Test response serialization
 	// req.query:

--- a/test/test-openapi-v3-recursive.json
+++ b/test/test-openapi-v3-recursive.json
@@ -68,8 +68,7 @@
 					"refStr": {
 						"$ref": "#/components/schemas/bodyObject/properties/arrRef/items/properties/arr/items"
 					}
-				},
-				"required": ["str1"]
+				}
 			}
 		}
 	}

--- a/test/test-openapi.v3.json
+++ b/test/test-openapi.v3.json
@@ -199,6 +199,17 @@
 				}
 			}
 		},
+		"/recursive": {
+			"post": {
+				"operationId": "postRecursive",
+				"summary": "placeholder",
+				"responses": {
+					"200": {
+						"description": "ok"
+					}
+				}
+			}
+		},
 		"/noParam": {
 			"get": {
 				"operationId": "getNoParam",

--- a/test/test-recursive.v3.js
+++ b/test/test-recursive.v3.js
@@ -53,3 +53,27 @@ test("route registration succeeds with recursion", (t, done) => {
 		}
 	});
 });
+
+test("route works with recursion", async (t) => {
+	const opts = {
+		specification: testSpec,
+		serviceHandlers,
+	};
+
+	const data = {
+		objRef: { str1: "test data" },
+	};
+	const fastify = Fastify(noStrict);
+	fastify.register(fastifyOpenapiGlue, opts);
+	const res = await fastify.inject({
+		method: "post",
+		url: "/recursive",
+		payload: data,
+	});
+	t.assert.equal(res.statusCode, 200, "request ok");
+	t.assert.deepStrictEqual(
+		JSON.parse(res.body),
+		data,
+		"recursive result is correct",
+	);
+});

--- a/test/test-recursive.v3.js
+++ b/test/test-recursive.v3.js
@@ -19,12 +19,27 @@ const noStrict = {
 	},
 };
 
+function countRefs(value) {
+	if (Array.isArray(value)) {
+		return value.reduce((count, item) => count + countRefs(item), 0);
+	}
+
+	if (value && typeof value === "object") {
+		return Object.entries(value).reduce((count, [key, child]) => {
+			return count + (key === "$ref" ? 1 : 0) + countRefs(child);
+		}, 0);
+	}
+
+	return 0;
+}
+
 test("route registration succeeds with recursion", (t, done) => {
 	const opts = {
 		specification: testSpec,
 		serviceHandlers,
 	};
 
+	const numRefsBefore = countRefs(testSpec);
 	const fastify = Fastify(noStrict);
 	fastify.register(fastifyOpenapiGlue, opts);
 	fastify.ready((err) => {
@@ -32,6 +47,8 @@ test("route registration succeeds with recursion", (t, done) => {
 			t.assert.fail("got unexpected error");
 		} else {
 			t.assert.ok(true, "no unexpected error");
+			const numRefsAfter = countRefs(testSpec);
+			t.assert.equal(numRefsAfter, numRefsBefore, "same number of refs");
 			done();
 		}
 	});


### PR DESCRIPTION
This PR fixes the mutation of the _specification_ parameter if the specification contains a $ref.
It also adds extra tests to avoid regression and to verify that recursive responses also work.