### PR TITLE
chore: replace createRequire by import { type: "json" }

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 ### Changed
  - chore: refactor parsing and generator
+ - chore: replace createRequire by import { type:"json" }
  
 ## [4.11.2] 05-05-2026
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 ### Changed
  - chore: refactor parsing and generator
  - chore: replace createRequire by import { type:"json" }
+ - chore: updated dependencies
+   - @biomejs/biome  ^2.4.14  →  ^2.4.16
+   - yaml             ^2.8.4  →   ^2.9.0
  
 ## [4.11.2] 05-05-2026
 ### Changed

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -2,13 +2,10 @@
 
 import { createHash } from "node:crypto";
 import { mkdirSync, writeFileSync } from "node:fs";
-import { createRequire } from "node:module";
 import { join } from "node:path";
+import pluginPackage from "../package.json" with { type: "json" };
 import { Parser } from "./Parser.js";
 import { templateInfo } from "./templates/templateTypes.js";
-
-const importJSON = createRequire(import.meta.url);
-const pluginPackage = await importJSON("../package.json");
 
 const contents = (dir, fileName, data) => {
 	return {

--- a/lib/templates/js/projectData.js
+++ b/lib/templates/js/projectData.js
@@ -1,15 +1,13 @@
-import { createRequire } from "node:module";
 import { join, relative } from "node:path";
 import generatePlugin from "./index.js";
 import generateInstructions from "./instructions.js";
+import pkgTemplate from "./package.json" with { type: "json" };
 import generateReadme from "./README.md.js";
 import generateSecurity from "./security.js";
 // manifest.js for javascript generation
 import generateService from "./service.js";
 import generateTest from "./test-plugin.js";
 
-const importJSON = createRequire(import.meta.url);
-const pkgTemplate = await importJSON("./package.json");
 const localFile = (fileName) => new URL(fileName, import.meta.url).pathname;
 
 const contents = (dir, fileName, data) => {

--- a/lib/templates/standaloneJS/projectData.js
+++ b/lib/templates/standaloneJS/projectData.js
@@ -1,16 +1,14 @@
 import { readFileSync } from "node:fs";
-import { createRequire } from "node:module";
 import { join, relative } from "node:path";
 import generatePlugin from "./index.js";
 import generateInstructions from "./instructions.js";
+import pkgTemplate from "./package.json" with { type: "json" };
 import generateReadme from "./README.md.js";
 import generateSecurity from "./security.js";
 // manifest.js for javascript generation
 import generateService from "./service.js";
 import generateTest from "./test-plugin.js";
 
-const importJSON = createRequire(import.meta.url);
-const pkgTemplate = await importJSON("./package.json");
 const localFile = (fileName) => new URL(fileName, import.meta.url).pathname;
 
 const contents = (dir, fileName, data) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,13 +11,13 @@
 			"dependencies": {
 				"@seriousme/openapi-schema-validator": "^2.9.0",
 				"fastify-plugin": "^5.1.0",
-				"yaml": "^2.8.4"
+				"yaml": "^2.9.0"
 			},
 			"bin": {
 				"openapi-glue": "bin/openapi-glue-cli.js"
 			},
 			"devDependencies": {
-				"@biomejs/biome": "^2.4.14",
+				"@biomejs/biome": "^2.4.16",
 				"expect-type": "^1.3.0",
 				"fastify": "^5.8.5",
 				"fastify-cli": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
 	"dependencies": {
 		"@seriousme/openapi-schema-validator": "^2.9.0",
 		"fastify-plugin": "^5.1.0",
-		"yaml": "^2.8.4"
+		"yaml": "^2.9.0"
 	},
 	"directories": {
 		"example": "./examples",
@@ -37,7 +37,7 @@
 		"bin": "./bin"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "^2.4.14",
+		"@biomejs/biome": "^2.4.16",
 		"expect-type": "^1.3.0",
 		"fastify": "^5.8.5",
 		"fastify-cli": "^8.0.0",

--- a/test/test-cli.js
+++ b/test/test-cli.js
@@ -1,10 +1,8 @@
 import { execSync } from "node:child_process";
-import { createRequire } from "node:module";
 import { test } from "node:test";
 import { fileURLToPath, URL } from "node:url";
 import { templateTypes } from "../lib/templates/templateTypes.js";
 
-const importJSON = createRequire(import.meta.url);
 const spec = "./test-swagger.v2";
 const cli = localFile("../bin/openapi-glue-cli.js");
 
@@ -19,7 +17,11 @@ for (const type of templateTypes) {
 	const specPath = localFile(`${spec}.json`);
 	const checksumFile = localFile(`${spec}.${type}.checksums.json`);
 	const project = `generated-${type}-project`;
-	const testChecksums = await importJSON(checksumFile);
+	const testChecksums = (
+		await import(checksumFile, {
+			with: { type: "json" },
+		})
+	).default;
 	await test(`cli ${type} does not error`, (t) => {
 		const checksums = JSON.parse(
 			execSync(`node ${cli} -c -p ${project} -t ${type} ${specPath}`),

--- a/test/test-cookie-param.v3.js
+++ b/test/test-cookie-param.v3.js
@@ -1,13 +1,10 @@
-import { createRequire } from "node:module";
 import { test } from "node:test";
 import Fastify from "fastify";
 import fastifyOpenapiGlue from "../index.js";
-
-const importJSON = createRequire(import.meta.url);
-
-const testSpec = await importJSON("./test-openapi-v3-cookie-param.json");
-
 import { Service } from "./service.js";
+import testSpec from "./test-openapi-v3-cookie-param.json" with {
+	type: "json",
+};
 
 const serviceHandlers = new Service();
 

--- a/test/test-custom-route-options.js
+++ b/test/test-custom-route-options.js
@@ -1,11 +1,7 @@
-import { createRequire } from "node:module";
 import { test } from "node:test";
 import Fastify from "fastify";
 import fastifyOpenapiGlue from "../index.js";
-
-const importJSON = createRequire(import.meta.url);
-
-const testSpec = await importJSON("./test-openapi.v3.json");
+import testSpec from "./test-openapi.v3.json" with { type: "json" };
 
 test("return route params from operationResolver", async (t) => {
 	const fastify = Fastify();

--- a/test/test-debuglogging.js
+++ b/test/test-debuglogging.js
@@ -1,16 +1,11 @@
-import { createRequire } from "node:module";
 // just test the basics to aid debugging
+
+import { Writable } from "node:stream";
 import { test } from "node:test";
 import Fastify from "fastify";
 import fastifyOpenapiGlue from "../index.js";
-
-const importJSON = createRequire(import.meta.url);
-
-import { Writable } from "node:stream";
-
-const testSpec = await importJSON("./test-openapi.v3.json");
-
 import { Service } from "./service.js";
+import testSpec from "./test-openapi.v3.json" with { type: "json" };
 
 const serviceHandlers = new Service();
 

--- a/test/test-generate-project.js
+++ b/test/test-generate-project.js
@@ -1,9 +1,7 @@
-import { createRequire } from "node:module";
 import { test } from "node:test";
 import { Generator } from "../lib/generator.js";
 import { templateTypes } from "../lib/templates/templateTypes.js";
 
-const importJSON = createRequire(import.meta.url);
 const localFile = (fileName) => new URL(fileName, import.meta.url).pathname;
 
 const specPath = localFile("./petstore-swagger.v2.json");
@@ -11,7 +9,11 @@ const specPath3 = localFile("./petstore-openapi.v3.json");
 const projectName = `generated-${templateTypes[0]}-project`;
 const dir = localFile("../examples");
 const nonExistentDir = localFile("./non-existent-directory");
-const spec301 = await importJSON(specPath3);
+const spec301 = (
+	await import(specPath3, {
+		with: { type: "json" },
+	})
+).default;
 
 const checksumOnly = false;
 const localPlugin = true;

--- a/test/test-generator.js
+++ b/test/test-generator.js
@@ -1,9 +1,7 @@
-import { createRequire } from "node:module";
 import { test } from "node:test";
 import { Generator } from "../lib/generator.js";
 import { templateTypes } from "../lib/templates/templateTypes.js";
 
-const importJSON = createRequire(import.meta.url);
 const localFile = (fileName) => new URL(fileName, import.meta.url).pathname;
 const dir = localFile(".");
 const checksumOnly = true;
@@ -16,7 +14,11 @@ for (const type of templateTypes) {
 	for (const spec of specs) {
 		const specFile = localFile(`${spec}.json`);
 		const checksumFile = localFile(`${spec}.${type}.checksums.json`);
-		const testChecksums = await importJSON(checksumFile);
+		const testChecksums = (
+			await import(checksumFile, {
+				with: { type: "json" },
+			})
+		).default;
 		const project = `generated-${type}-project`;
 		const generator = new Generator(checksumOnly, localPlugin);
 		await test(`generator generates ${type} project data for ${spec}`, async (t) => {

--- a/test/test-plugin.v2.js
+++ b/test/test-plugin.v2.js
@@ -1,20 +1,15 @@
-import { createRequire } from "node:module";
 import { test } from "node:test";
 import Fastify from "fastify";
 import fastifyOpenapiGlue from "../index.js";
-
-const importJSON = createRequire(import.meta.url);
-const localFile = (fileName) => new URL(fileName, import.meta.url).pathname;
-
-const testSpec = await importJSON("./test-swagger.v2.json");
-const petStoreSpec = await importJSON("./petstore-swagger.v2.json");
-const testSpecYAML = localFile("./test-swagger.v2.yaml");
-const genericPathItemsSpec = await importJSON(
-	"./test-swagger-v2-generic-path-items.json",
-);
-
+import petStoreSpec from "./petstore-swagger.v2.json" with { type: "json" };
 import { Service } from "./service.js";
+import testSpec from "./test-swagger.v2.json" with { type: "json" };
+import genericPathItemsSpec from "./test-swagger-v2-generic-path-items.json" with {
+	type: "json",
+};
 
+const localFile = (fileName) => new URL(fileName, import.meta.url).pathname;
+const testSpecYAML = localFile("./test-swagger.v2.yaml");
 const serviceHandlers = new Service();
 
 const noStrict = {

--- a/test/test-plugin.v3.content.js
+++ b/test/test-plugin.v3.content.js
@@ -1,13 +1,8 @@
-import { createRequire } from "node:module";
 import { test } from "node:test";
 import Fastify from "fastify";
 import fastifyOpenapiGlue from "../index.js";
-
-const importJSON = createRequire(import.meta.url);
-
-const testSpec = await importJSON("./test-openapi.v3.content.json");
-
 import { Service } from "./service.js";
+import testSpec from "./test-openapi.v3.content.json" with { type: "json" };
 
 const serviceHandlers = new Service();
 

--- a/test/test-plugin.v3.js
+++ b/test/test-plugin.v3.js
@@ -1,19 +1,15 @@
-import { createRequire } from "node:module";
 import { test } from "node:test";
 import Fastify from "fastify";
 import fastifyOpenapiGlue from "../index.js";
-
-const importJSON = createRequire(import.meta.url);
-const localFile = (fileName) => new URL(fileName, import.meta.url).pathname;
-
-const testSpec = await importJSON("./test-openapi.v3.json");
-const petStoreSpec = await importJSON("./petstore-openapi.v3.json");
-const testSpecYAML = localFile("./test-openapi.v3.yaml");
-const genericPathItemsSpec = await importJSON(
-	"./test-openapi-v3-generic-path-items.json",
-);
-
+import petStoreSpec from "./petstore-openapi.v3.json" with { type: "json" };
 import { Service } from "./service.js";
+import testSpec from "./test-openapi.v3.json" with { type: "json" };
+import genericPathItemsSpec from "./test-openapi-v3-generic-path-items.json" with {
+	type: "json",
+};
+
+const localFile = (fileName) => new URL(fileName, import.meta.url).pathname;
+const testSpecYAML = localFile("./test-openapi.v3.yaml");
 
 const serviceHandlers = new Service();
 

--- a/test/test-plugin.v3.multipleMimeTypes.js
+++ b/test/test-plugin.v3.multipleMimeTypes.js
@@ -1,13 +1,10 @@
-import { createRequire } from "node:module";
 import { test } from "node:test";
 import Fastify from "fastify";
 import fastifyOpenapiGlue from "../index.js";
-
-const importJSON = createRequire(import.meta.url);
-
-const testSpec = await importJSON("./test-openapi.v3.multipleMimeTypes.json");
-
 import { Service } from "./service.multipleMimeTypes.js";
+import testSpec from "./test-openapi.v3.multipleMimeTypes.json" with {
+	type: "json",
+};
 
 const serviceHandlers = new Service();
 

--- a/test/test-recursive.v3.js
+++ b/test/test-recursive.v3.js
@@ -1,12 +1,9 @@
-import { createRequire } from "node:module";
 import { test } from "node:test";
 import Fastify from "fastify";
 import fastifyOpenapiGlue from "../index.js";
+import testSpec from "./test-openapi-v3-recursive.json" with { type: "json" };
 
-const importJSON = createRequire(import.meta.url);
 const localFile = (fileName) => new URL(fileName, import.meta.url).pathname;
-
-const testSpec = await importJSON("./test-openapi-v3-recursive.json");
 
 class Service {
 	async postRecursive(req) {

--- a/test/test-securityHandlers.js
+++ b/test/test-securityHandlers.js
@@ -1,10 +1,6 @@
-import { createRequire } from "node:module";
 import { test } from "node:test";
 import Fastify from "fastify";
 import fastifyOpenapiGlue from "../index.js";
-
-const importJSON = createRequire(import.meta.url);
-
 import securityHandlers from "./security.js";
 import { Service } from "./service.js";
 
@@ -27,8 +23,16 @@ await doTest(
 await doTest("v3", "./test-openapi.v3.json", "./petstore-openapi.v3.json", "");
 
 async function doTest(version, testSpecName, petStoreSpecName, prefix) {
-	const testSpec = await importJSON(testSpecName);
-	const petStoreSpec = await importJSON(petStoreSpecName);
+	const testSpec = (
+		await import(testSpecName, {
+			with: { type: "json" },
+		})
+	).default;
+	const petStoreSpec = (
+		await import(petStoreSpecName, {
+			with: { type: "json" },
+		})
+	).default;
 
 	const invalidSecurityOpts = {
 		specification: testSpec,

--- a/test/test-warnings.js
+++ b/test/test-warnings.js
@@ -1,14 +1,10 @@
-import { createRequire } from "node:module";
 import { test } from "node:test";
 import Fastify from "fastify";
 import fastifyOpenapiGlue from "../index.js";
 import { Service } from "./service.js";
+import testSpec from "./test-openapi.v3.json" with { type: "json" };
 
 const service = new Service();
-
-const importJSON = createRequire(import.meta.url);
-
-const testSpec = await importJSON("./test-openapi.v3.json");
 const calls = [];
 
 function makeWarningHandler(t) {


### PR DESCRIPTION
Now that NodeJS 20 is EOL we can clean up old constructs
This PR:
 - replaces createRequire by import { type:"json" }
 - updates dependencies
   - @biomejs/biome  ^2.4.14  →  ^2.4.16
   - yaml             ^2.8.4  →   ^2.9.0