### PR TITLE
chore: update dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 ## [Unreleased]
 ### Changed
 
+## [4.11.4] 06-08-2026
+### Changed
+ - chore: updated dependencies
+   - @biomejs/biome                       ^2.4.16  →   ^2.5.7
+   - @seriousme/openapi-schema-validator   ^2.9.0  →   ^2.9.1
+   - expect-type                           ^1.3.0  →   ^1.4.0
+   - fastify                               ^5.8.5  →  ^5.11.2
+
 ## [4.11.3] 30-05-2026
 ### Changed
  - chore: refactor parsing and generator

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 ### Changed
 
-## [4.11.4] 06-08-2026
+## [4.11.4] 07-08-2026
 ### Changed
  - chore: updated dependencies
    - @biomejs/biome                       ^2.4.16  →   ^2.5.7

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -17,7 +17,7 @@
 	"linter": {
 		"enabled": true,
 		"rules": {
-			"recommended": true,
+			"preset": "recommended",
 			"complexity": { "useLiteralKeys": "off" },
 			"style": {
 				"noParameterAssign": "error",

--- a/examples/generated-javascript-project/package.json
+++ b/examples/generated-javascript-project/package.json
@@ -12,10 +12,10 @@
     "test": "test"
   },
   "dependencies": {
-    "fastify-plugin": "^5.1.0"
+    "fastify-plugin": "^6.0.0"
   },
   "devDependencies": {
-    "fastify": "^5.8.5",
+    "fastify": "^5.11.2",
     "fastify-cli": "^8.0.0"
   }
 }

--- a/examples/generated-standaloneJS-project/package.json
+++ b/examples/generated-standaloneJS-project/package.json
@@ -12,10 +12,10 @@
     "test": "test"
   },
   "dependencies": {
-    "fastify-plugin": "^5.1.0"
+    "fastify-plugin": "^6.0.0"
   },
   "devDependencies": {
-    "fastify": "^5.8.5",
+    "fastify": "^5.11.2",
     "fastify-cli": "^8.0.0"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "4.11.3",
 			"license": "MIT",
 			"dependencies": {
-				"@seriousme/openapi-schema-validator": "^2.9.0",
+				"@seriousme/openapi-schema-validator": "^2.9.1",
 				"fastify-plugin": "^6.0.0",
 				"yaml": "^2.9.0"
 			},
@@ -17,9 +17,9 @@
 				"openapi-glue": "bin/openapi-glue-cli.js"
 			},
 			"devDependencies": {
-				"@biomejs/biome": "^2.4.16",
-				"expect-type": "^1.3.0",
-				"fastify": "^5.8.5",
+				"@biomejs/biome": "^2.5.7",
+				"expect-type": "^1.4.0",
+				"fastify": "^5.11.2",
 				"fastify-cli": "^8.0.0",
 				"typescript": "^7.0.2"
 			},
@@ -28,9 +28,9 @@
 			}
 		},
 		"node_modules/@biomejs/biome": {
-			"version": "2.5.6",
-			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.6.tgz",
-			"integrity": "sha512-lxVNjv7UF6KfhMJfL9gaUHbWdJdHbsAj6OSmwSYNdhRuG67NxNQ4Xdvh3TUxsSK9sBzJBQhEJj3AopmmNJ5pSA==",
+			"version": "2.5.7",
+			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.7.tgz",
+			"integrity": "sha512-zr8K/DcY5tYsQOQwqMJ0AWElo6QgmgNI7idXgXLhevVszlt8RGVpesEJPqx3ThazLaOwjJ5Y8fz3BtH5fGZNsw==",
 			"dev": true,
 			"license": "MIT OR Apache-2.0",
 			"bin": {
@@ -44,20 +44,20 @@
 				"url": "https://opencollective.com/biome"
 			},
 			"optionalDependencies": {
-				"@biomejs/cli-darwin-arm64": "2.5.6",
-				"@biomejs/cli-darwin-x64": "2.5.6",
-				"@biomejs/cli-linux-arm64": "2.5.6",
-				"@biomejs/cli-linux-arm64-musl": "2.5.6",
-				"@biomejs/cli-linux-x64": "2.5.6",
-				"@biomejs/cli-linux-x64-musl": "2.5.6",
-				"@biomejs/cli-win32-arm64": "2.5.6",
-				"@biomejs/cli-win32-x64": "2.5.6"
+				"@biomejs/cli-darwin-arm64": "2.5.7",
+				"@biomejs/cli-darwin-x64": "2.5.7",
+				"@biomejs/cli-linux-arm64": "2.5.7",
+				"@biomejs/cli-linux-arm64-musl": "2.5.7",
+				"@biomejs/cli-linux-x64": "2.5.7",
+				"@biomejs/cli-linux-x64-musl": "2.5.7",
+				"@biomejs/cli-win32-arm64": "2.5.7",
+				"@biomejs/cli-win32-x64": "2.5.7"
 			}
 		},
 		"node_modules/@biomejs/cli-darwin-arm64": {
-			"version": "2.5.6",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.5.6.tgz",
-			"integrity": "sha512-zMOLZP4oMrjh6m1zcSj1ud2awUPgTuMVbmQhYYWL7J8HwCnbHHBvTm7VBTRuY7epT5bez76IpKYQ11ZAqHFlnw==",
+			"version": "2.5.7",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.5.7.tgz",
+			"integrity": "sha512-vxo/Ls3/PYdQWyLhYYcgMOCzQypAjcY+iihS8M0wW03l16TCLW4zqZzGo75gm1VdCMj38hTVZ31KBWrZ4G9dJw==",
 			"cpu": [
 				"arm64"
 			],
@@ -72,9 +72,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-darwin-x64": {
-			"version": "2.5.6",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.5.6.tgz",
-			"integrity": "sha512-JAC1VqzvO7Th5ZplU0G2uGfkZbxEe9uDDektPAhF0JLusoz1w+T4okp2bkykI0bbaO2vslKiRfj4gU43JaGreA==",
+			"version": "2.5.7",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.5.7.tgz",
+			"integrity": "sha512-Cd3Ga61amT/Yl/0x8elP5hhGYaFy4bw6WuysTgf7oo8TA5tJ5A1k+DkVoJ2BHbTVil51gTX9VPzArnrlLJ3Kyg==",
 			"cpu": [
 				"x64"
 			],
@@ -89,9 +89,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-arm64": {
-			"version": "2.5.6",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.5.6.tgz",
-			"integrity": "sha512-6XsYwCFkp5sMxl85ffhgeGpGgs6A7dRYFnkceZ7WVxvycuTnGdD5xa534Z3xfrBQ0JCMK/mujT6ZNPJoghedwg==",
+			"version": "2.5.7",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.5.7.tgz",
+			"integrity": "sha512-rR2QE0yF2GYSuYuKIa7pKvODGJqnOH+2eDREAM8wV+mWKSkMQKdAp4zXEZfTaxY8PMoNONnpgSWcBCyLDPDOKg==",
 			"cpu": [
 				"arm64"
 			],
@@ -109,9 +109,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-arm64-musl": {
-			"version": "2.5.6",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.5.6.tgz",
-			"integrity": "sha512-eUa3jeeYvfMt19LBeh6E5PUZpxnTC4JqNWo+EDjTtQjAr2xLGnWaxACtVU1DQqmHYbvThlJzLX+ZsYgrqh2qVw==",
+			"version": "2.5.7",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.5.7.tgz",
+			"integrity": "sha512-xPI5yB6XlpDbNkS+bm1t42olw5c4l3UrlOmLg7KtLJvjvkNF/1V4tnUgfkylGIeb3u/T+BzMGYqgQhzjAoJzuQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -129,9 +129,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-x64": {
-			"version": "2.5.6",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.6.tgz",
-			"integrity": "sha512-Pop9VXCFUhFTMfFefZ39S+u2rOPyNp5iHlxbZRwXGACHLy2r0jjiRgJHmaEKJzL3SyxlVeGShXhvvElvWowonA==",
+			"version": "2.5.7",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.7.tgz",
+			"integrity": "sha512-FQgqJhscrqJUFptGaRSUJWlXAExwWcDwLuK49dvKfkQ1bB5SEEyFssnsxQY83Xm6jR0EbbX3+8+D5bfvYqUG2Q==",
 			"cpu": [
 				"x64"
 			],
@@ -149,9 +149,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-x64-musl": {
-			"version": "2.5.6",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.5.6.tgz",
-			"integrity": "sha512-2Vp13QdKysH3HIWLaYLhUUwbK+jbZonJD1K+Lr0d0RO4wH7mkYd43vJixEDm8cUWrowoRz4UUHF1nm9Ae7ym8A==",
+			"version": "2.5.7",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.5.7.tgz",
+			"integrity": "sha512-rE5VZi+qtmPgQH+l7jVxYoZ18b/TiHEhulhMpjmCZH1PltSbjRcxNWywC3HZ9tYottG7ORkeTtoscBilKSBm0g==",
 			"cpu": [
 				"x64"
 			],
@@ -169,9 +169,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-win32-arm64": {
-			"version": "2.5.6",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.5.6.tgz",
-			"integrity": "sha512-tDGshcm6BdkZOCGnTDX0Y8/U4IfBSlnUU7T56nNDuPEfed+aHg+u8G36NB43fJVl0Os6+QURXIE1yuD7AaEofA==",
+			"version": "2.5.7",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.5.7.tgz",
+			"integrity": "sha512-Oq4x0CCwP4jirrcTywXs5kOGZ4v5vuEP+gWrbtjApOA2CL9F3F9GlIdQIci8AKSCa/zURanMRpX/4wQ7Am6hHg==",
 			"cpu": [
 				"arm64"
 			],
@@ -186,9 +186,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-win32-x64": {
-			"version": "2.5.6",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.5.6.tgz",
-			"integrity": "sha512-WN05KwXnTO/2J45RQPvzZMXf7tZUIofHoR35xIPfCo7pQ2RFidxI8sfb5mGsaTxdMmEOzHzOPRCdA5/fCpc7xQ==",
+			"version": "2.5.7",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.5.7.tgz",
+			"integrity": "sha512-V+0wu/nrj2S+MhP4EQ0uHNolP0IALEsz45pg0WoKkHfDeh0+ItHwP/p7bX5RPoMOl9NkpHYWdYPhIcy2mACHvQ==",
 			"cpu": [
 				"x64"
 			],
@@ -344,15 +344,15 @@
 			"license": "MIT"
 		},
 		"node_modules/@seriousme/openapi-schema-validator": {
-			"version": "2.9.0",
-			"resolved": "https://registry.npmjs.org/@seriousme/openapi-schema-validator/-/openapi-schema-validator-2.9.0.tgz",
-			"integrity": "sha512-bP/48Il7RMxhohq36Vg0c25tnCKOO+oEv8XSxDefuUBj0W8fYzL2Yb6C8tji0WBXykZ1S/79AWbrzGLfCG2dYw==",
+			"version": "2.9.1",
+			"resolved": "https://registry.npmjs.org/@seriousme/openapi-schema-validator/-/openapi-schema-validator-2.9.1.tgz",
+			"integrity": "sha512-EgGqVIP8xiKHmNTHWbrxec+RhD/WPUay7D/erEc7vWoZKxTT9f2aCEu1egKVpxcEbT1z0wdAbWFR9o2Is5FJEw==",
 			"license": "MIT",
 			"dependencies": {
-				"ajv": "^8.18.0",
+				"ajv": "^8.20.0",
 				"ajv-draft-04": "^1.0.0",
 				"ajv-formats": "^3.0.1",
-				"yaml": "^2.8.3"
+				"yaml": "^2.9.0"
 			},
 			"bin": {
 				"bundle-api": "bin/bundle-api-cli.js",
@@ -707,9 +707,9 @@
 			"license": "MIT"
 		},
 		"node_modules/ajv": {
-			"version": "8.18.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-			"integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+			"version": "8.20.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+			"integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
 			"license": "MIT",
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
@@ -981,9 +981,9 @@
 			"license": "MIT"
 		},
 		"node_modules/fast-uri": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-			"integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+			"integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
 			"funding": [
 				{
 					"type": "github",
@@ -997,9 +997,9 @@
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/fastify": {
-			"version": "5.11.0",
-			"resolved": "https://registry.npmjs.org/fastify/-/fastify-5.11.0.tgz",
-			"integrity": "sha512-Y/Ecx1yt0hYzrQR+QVLbxaUN8wCX+MQzMevh29r5RRvlOIArmi4+WAXXaGl5Hw5gBr2wduZpZaT3gRCnXoyVgA==",
+			"version": "5.11.2",
+			"resolved": "https://registry.npmjs.org/fastify/-/fastify-5.11.2.tgz",
+			"integrity": "sha512-i/eJG7nXR9OkbFgoX4jFiPOHoRq0rXqDACVAXELh5Fdg6BFBErIVZ8MyibGCwup9Go1pYrxZJ0ogIub8vVdEcQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -1136,9 +1136,9 @@
 			}
 		},
 		"node_modules/find-my-way": {
-			"version": "9.6.0",
-			"resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-9.6.0.tgz",
-			"integrity": "sha512-Zf4Xve4RymLl7NgaavNebZ01joJ8MfVerOG43wy7SHLO+r+K0C6d/SE0BiR7AV5V1VOCFlOP7ecdo+I4qmiHrQ==",
+			"version": "9.7.0",
+			"resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-9.7.0.tgz",
+			"integrity": "sha512-f2JHn75x2JlwUwLenZypgczR7YWMb/uO9BvUXtus+JMgkbIkLADd38cI4EiV+OQqrGo1Zlq6V8wnqMJ8e62wUQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
 		"openapi-glue": "./bin/openapi-glue-cli.js"
 	},
 	"dependencies": {
-		"@seriousme/openapi-schema-validator": "^2.9.0",
+		"@seriousme/openapi-schema-validator": "^2.9.1",
 		"fastify-plugin": "^6.0.0",
 		"yaml": "^2.9.0"
 	},
@@ -37,9 +37,9 @@
 		"bin": "./bin"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "^2.4.16",
-		"expect-type": "^1.3.0",
-		"fastify": "^5.8.5",
+		"@biomejs/biome": "^2.5.7",
+		"expect-type": "^1.4.0",
+		"fastify": "^5.11.2",
 		"fastify-cli": "^8.0.0",
 		"typescript": "^7.0.2"
 	},


### PR DESCRIPTION
### Changed
 - chore: updated dependencies
   - @biomejs/biome                       ^2.4.16  →   ^2.5.7
   - @seriousme/openapi-schema-validator   ^2.9.0  →   ^2.9.1
   - expect-type                           ^1.3.0  →   ^1.4.0
   - fastify                               ^5.8.5  →  ^5.11.2